### PR TITLE
Genereates binaries for x86_64 and arm-32

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ on:
 permissions:
   contents: write
 jobs:
-  release:
+  build:
     name: Release - ${{ matrix.platform.release_for }}
     strategy:
       matrix:
@@ -34,26 +34,28 @@ jobs:
           command: ${{ matrix.platform.command }}
           target: ${{ matrix.platform.target }}
           args: "--locked --release"
-      - name: Publish GitHub release
+      - name: Package as archive
+        shell: bash
+        run:  |
+          cd target/${{ matrix.platform.target }}/release
+          tar czvf ../../../${{ matrix.platform.name }} ${{ matrix.platform.bin }}
+          cd -
+      - name: Upload package as artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: binaries
+          path: ${{ matrix.platform.name }}
+    
+  publish:
+    name: Publish binaries
+    runs-on: ${{ matrix.platform.os }}
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: binaries
+          path: ./binaries
+      - name: Publish artifacts
         uses: softprops/action-gh-release@v1
         with:
-          files: "localtunnel*"
-
-    # publish-crate:
-    #   runs-on: ubuntu-latest
-    #   environment: production
-    #   env:
-    #     CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-    #   needs: [github-artifact]
-    #   strategy:
-    #       matrix:
-    #           package: [youtube-transcript]
-    #   steps:
-    #       - name: Checkout
-    #         uses: actions/checkout@v3
-    #       - name: Rust tooling
-    #         uses: dtolnay/rust-toolchain@stable
-    #       - name: Cache rust
-    #         uses: Swatinem/rust-cache@v2
-    #       - name: publish
-    #         run: cargo publish -p ${{ matrix.package }}
+          files: ./binaries/*

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,7 +48,7 @@ jobs:
     
   publish:
     name: Publish binaries
-    runs-on: ${{ matrix.platform.os }}
+    runs-on: ubuntu-latest
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,6 +47,7 @@ jobs:
           path: ${{ matrix.platform.name }}
     
   publish:
+    needs: [build]
     name: Publish binaries
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: CI
+name: test
 
 on:
     pull_request:
@@ -6,7 +6,7 @@ on:
           - main
         paths-ignore:
           - '.github/workflows/publish.yml'
-          - '.github/workflows/ci.yml'
+          - '.github/workflows/test.yml'
           - '.github/FUNDING.yml'
           - '**README.md'
           - '.gitignore'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -912,7 +912,7 @@ checksum = "e34f76eb3611940e0e7d53a9aaa4e6a3151f69541a282fd0dad5571420c53ff1"
 
 [[package]]
 name = "localtunnel"
-version = "0.1.1"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "localtunnel-client"
-version = "0.1.1"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "log",
@@ -937,7 +937,7 @@ dependencies = [
 
 [[package]]
 name = "localtunnel-server"
-version = "0.1.1"
+version = "0.2.1"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -912,7 +912,7 @@ checksum = "e34f76eb3611940e0e7d53a9aaa4e6a3151f69541a282fd0dad5571420c53ff1"
 
 [[package]]
 name = "localtunnel"
-version = "0.2.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -925,11 +925,10 @@ dependencies = [
 
 [[package]]
 name = "localtunnel-client"
-version = "0.2.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "log",
- "openssl",
  "reqwest",
  "serde",
  "tokio",
@@ -937,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "localtunnel-server"
-version = "0.2.1"
+version = "0.1.2"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -947,7 +946,6 @@ dependencies = [
  "hyper 1.0.0-rc.1",
  "lazy_static",
  "log",
- "openssl",
  "regex",
  "reqwest",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,4 @@
 [workspace]
-package.version = "0.1.2"
 package.edition = "2021"
 package.license = "MIT"
 package.repository = "https://github.com/kaichaosun/rlt"
@@ -10,4 +9,3 @@ tokio = { version = "1.23.0", features = ["full"] }
 anyhow = { version = "1.0", features = ["backtrace"] }
 log = "0.4"
 serde = { version = "1.0", features = ["derive"] }
-reqwest = { version = "0.11", features = ["json"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-package.version = "0.1.1"
+package.version = "0.2.1"
 package.edition = "2021"
 package.license = "MIT"
 package.repository = "https://github.com/kaichaosun/rlt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,13 @@
 [workspace]
-package.version = "0.2.1"
+package.version = "0.1.2"
 package.edition = "2021"
 package.license = "MIT"
 package.repository = "https://github.com/kaichaosun/rlt"
 members = ["cli", "client", "server"]
 
 [workspace.dependencies]
-openssl = { version = "0.10", features = ["vendored"] }
 tokio = { version = "1.23.0", features = ["full"] }
 anyhow = { version = "1.0", features = ["backtrace"] }
 log = "0.4"
 serde = { version = "1.0", features = ["derive"] }
-reqwest = { version = "0.11", features = ["json"], default-features = false }
+reqwest = { version = "0.11", features = ["json"] }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "localtunnel"
-version.workspace = true
+version = "0.1.2"
 edition.workspace = true
 description = "A CLI to proxy with localtunnel server."
 license.workspace = true

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -10,8 +10,8 @@ repository.workspace = true
 
 [dependencies]
 clap = { version = "3.2.14", features = ["derive"] }
-localtunnel-client = { path = "../client" }
-localtunnel-server = { path = "../server" }
+localtunnel-client = { path = "../client", version = "0.1.2" }
+localtunnel-server = { path = "../server", version = "0.1.2" }
 tokio = { workspace = true }
 log = { workspace = true }
 env_logger = "0.9"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -10,8 +10,8 @@ repository.workspace = true
 
 [dependencies]
 clap = { version = "3.2.14", features = ["derive"] }
-localtunnel-client = { path = "../client", version = "0.1.1" }
-localtunnel-server = { path = "../server", version = "0.1.1" }
+localtunnel-client = { path = "../client" }
+localtunnel-server = { path = "../server" }
 tokio = { workspace = true }
 log = { workspace = true }
 env_logger = "0.9"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "localtunnel-client"
-version.workspace = true
+version = "0.1.2"
 edition.workspace = true
 description = "A client to connect with localtunnel server."
 license.workspace = true
@@ -9,7 +9,7 @@ repository.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-reqwest = { version = "0.11", default-features = false }
+reqwest = { version = "0.11", features = ["json"], default-features = false }
 serde = { workspace = true }
 tokio = { workspace = true }
 anyhow = { workspace = true }

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -9,8 +9,7 @@ repository.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-reqwest = { workspace = true, default-features = false }
-openssl = { workspace = true }
+reqwest = { version = "0.11", default-features = false }
 serde = { workspace = true }
 tokio = { workspace = true }
 anyhow = { workspace = true }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -15,8 +15,7 @@ log = { workspace = true }
 actix-web = "4"
 serde = { workspace = true }
 hyper = { version = "1.0.0-rc.1", features = ["full"] }
-reqwest = { workspace = true, features = ["blocking"] }
-openssl = { workspace = true }
+reqwest = { workspace = true, features = ["blocking", "native-tls-vendored"] }
 lazy_static = "1.4.0"
 envy = "0.4"
 dotenv = "0.15.0"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "localtunnel-server"
-version.workspace = true
+version = "0.1.2"
 edition.workspace = true
 description = "Server implementation of localtunnel."
 license.workspace = true
@@ -15,7 +15,11 @@ log = { workspace = true }
 actix-web = "4"
 serde = { workspace = true }
 hyper = { version = "1.0.0-rc.1", features = ["full"] }
-reqwest = { workspace = true, features = ["blocking", "native-tls-vendored"] }
+reqwest = { version = "0.11", features = [
+    "json",
+    "blocking",
+    "native-tls-vendored",
+] }
 lazy_static = "1.4.0"
 envy = "0.4"
 dotenv = "0.15.0"


### PR DESCRIPTION
Fixes https://github.com/kaichaosun/rlt/issues/22

single source of truth from Cargo workspace

Features:
- Release binaries for arm 32 and x86_64 architectures.

Here's a release that's published through github actions: https://github.com/akhildevelops/rlt/releases/tag/v0.2.1