### PR TITLE
proxy: fix HTTP Upgrades (websockets)

### DIFF
--- a/server/src/proxy.rs
+++ b/server/src/proxy.rs
@@ -37,6 +37,7 @@ pub async fn proxy_handler(
 
     if !req.headers().contains_key(UPGRADE) {
         let (mut sender, conn) = hyper::client::conn::http1::handshake(client_stream).await?;
+        let conn = conn.with_upgrades();
         tokio::spawn(async move {
             if let Err(err) = conn.await {
                 log::error!("Connection failed: {:?}", err);


### PR DESCRIPTION
This fixes tunneled connection upgrades, primarily websocket connections.