### PR TITLE
fix empty_line_after_doc_comments clippy warning

### DIFF
--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -1,6 +1,6 @@
-/// Start a localtunnel server,
-/// request a proxy endpoint at `domain.tld/<your-endpoint>`,
-/// user's request then proxied via `<your-endpoint>.domain.tld`.
+//! Start a localtunnel server,
+//! request a proxy endpoint at `domain.tld/<your-endpoint>`,
+//! user's request then proxied via `<your-endpoint>.domain.tld`.
 
 #[macro_use]
 extern crate lazy_static;


### PR DESCRIPTION
See https://rust-lang.github.io/rust-clippy/master/index.html#empty_line_after_doc_comments