### PR TITLE
fix(client): recover the tunnel when the remote closes pooled sockets (#8)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1051,6 +1051,7 @@ name = "localtunnel-client"
 version = "0.1.7"
 dependencies = [
  "anyhow",
+ "localtunnel-server",
  "log",
  "reqwest",
  "serde",

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -85,6 +85,8 @@ async fn main() -> Result<()> {
                 max_conn,
                 credential,
                 reregister_after: None,
+                reconnect_base_delay: None,
+                reconnect_max_delay: None,
             };
             let result = open_tunnel(config).await?;
             log::info!("Tunnel url: {:?}", result);

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -19,3 +19,6 @@ socket2 = { workspace = true }
 [features]
 default = ["reqwest/default"]
 rustls-tls = ["reqwest/rustls-tls"]
+
+[dev-dependencies]
+localtunnel-server = { path = "../server" }

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -7,11 +7,11 @@ use std::time::Instant;
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use socket2::{SockRef, TcpKeepalive};
-use tokio::io;
+use tokio::io::{self, AsyncWriteExt};
 use tokio::net::TcpStream;
 pub use tokio::sync::broadcast;
 use tokio::sync::{mpsc, Semaphore};
-use tokio::time::{sleep, Duration};
+use tokio::time::{sleep, timeout, Duration};
 
 pub const PROXY_SERVER: &str = "https://your-domain.com";
 pub const LOCAL_HOST: &str = "127.0.0.1";
@@ -21,6 +21,55 @@ const TCP_KEEPALIVE_TIME: Duration = Duration::from_secs(30);
 const TCP_KEEPALIVE_INTERVAL: Duration = Duration::from_secs(10);
 #[cfg(not(target_os = "windows"))]
 const TCP_KEEPALIVE_RETRIES: u32 = 5;
+
+/// Size of the buffer used to wait for the first byte of a request. One byte is
+/// enough because the read is a *detector* ("data arrived" vs "FIN arrived"), not
+/// a parser — the bytes are peeked, not consumed, and the splice reads them again.
+/// The buffer must not be empty: peeking into an empty slice returns `Ok(0)` and
+/// would look like a false EOF.
+const FIRST_BYTE_PROBE: usize = 1;
+
+/// Upper bound on "let the other direction drain its tail" after one direction has
+/// already reached EOF. It is only ever armed *after* an EOF, so a connection with
+/// both halves alive (a websocket, an SSE stream) is never affected by it: neither
+/// copy completes, so the grace timeout is not even created.
+const HALF_CLOSE_GRACE: Duration = Duration::from_secs(10);
+
+/// Pause before re-offering a socket after the remote closed an idle pooled one.
+/// This is a safety belt, not decoration: before this fix such a task hung forever,
+/// now it finishes in milliseconds, and without a pause `max_conn` tasks would spin
+/// in a hot reconnect loop while the endpoint keeps refusing sockets. 500 ms caps
+/// that at two attempts per second per task while still fitting inside the 5 s
+/// recovery window the regression test asserts. Phase 3 replaces this constant with
+/// exponential backoff plus deterministic jitter.
+const RECONNECT_AFTER_IDLE_CLOSE: Duration = Duration::from_millis(500);
+
+/// How a single tunnel connection ended.
+///
+/// Modelled as an explicit outcome rather than `Result<()>` because the interesting
+/// cases are not errors: a remote that closes a pooled socket it no longer needs, and
+/// a local service that is momentarily down, are both normal states of a tunnel. Only
+/// genuine I/O failures stay in `Err`. Phase 2 maps these variants onto `RoundHealth`,
+/// which is why the distinction between a remote-side and a local-side failure has to
+/// survive all the way up to the caller.
+#[derive(Debug)]
+enum ConnOutcome {
+    /// Bytes flowed in at least one direction and the connection finished cleanly.
+    /// `bytes` is the total moved in both directions.
+    Served { bytes: u64 },
+    /// The remote closed (FIN / RST / keepalive timeout) before sending a single
+    /// request byte. `lifetime` is measured from the moment the socket entered
+    /// `proxy_through` until the read returned 0; phase 2 compares it against
+    /// `IDLE_CLOSE_MIN_LIFETIME` to tell "server went away" from routine pool churn.
+    RemoteClosedIdle { lifetime: Duration },
+    /// A request arrived but the local service refused the connection. Note this is a
+    /// *local* failure — the remote endpoint is healthy, so it must never count
+    /// against endpoint health (see the docs on [`RoundHealth`]).
+    LocalUnavailable,
+    /// The TCP connect to the endpoint itself failed. Produced by
+    /// `tunnel_one_connection`, not by `proxy_through`.
+    RemoteConnectFailed,
+}
 
 /// Default for [`ClientConfig::reregister_after`]: how long the remote endpoint
 /// must be *continuously* unreachable before we re-register. Time-based rather
@@ -308,29 +357,124 @@ async fn tunnel_one_connection(
     health: &RoundHealth,
 ) {
     log::debug!("Connecting to remote: {}:{}", server_host, server_port);
-    let remote_stream = match TcpStream::connect(format!("{server_host}:{server_port}")).await {
+    let outcome = match TcpStream::connect(format!("{server_host}:{server_port}")).await {
         Ok(stream) => {
             health.record_success();
-            stream
+            let proxy_result = proxy_through(stream, local_host, local_port).await;
+            // The remote stayed reachable for the whole life of this connection, which
+            // just ended. Refresh the timestamp so that if reconnects now start failing,
+            // downtime is measured from this moment rather than from when the connection
+            // was first opened — otherwise an idle tunnel that drops would report a huge
+            // downtime on the very first failure and re-register on a momentary blip.
+            health.record_success();
+            match proxy_result {
+                Ok(outcome) => outcome,
+                Err(err) => {
+                    log::error!("Proxy error: {:?}", err);
+                    sleep(Duration::from_secs(10)).await;
+                    return;
+                }
+            }
         }
         Err(err) => {
             let down_for = health.record_failure();
             log::error!("Remote connect failed (down for {:?}): {:?}", down_for, err);
-            sleep(Duration::from_secs(10)).await;
-            return;
+            ConnOutcome::RemoteConnectFailed
         }
     };
 
-    let proxy_result = proxy_through(remote_stream, local_host, local_port).await;
-    // The remote stayed reachable for the whole life of this connection, which
-    // just ended. Refresh the timestamp so that if reconnects now start failing,
-    // downtime is measured from this moment rather than from when the connection
-    // was first opened — otherwise an idle tunnel that drops would report a huge
-    // downtime on the very first failure and re-register on a momentary blip.
-    health.record_success();
-    if let Err(err) = proxy_result {
-        log::error!("Proxy error: {:?}", err);
-        sleep(Duration::from_secs(10)).await;
+    match outcome {
+        ConnOutcome::Served { bytes } => {
+            log::debug!("Tunnel connection served {} bytes", bytes);
+        }
+        ConnOutcome::RemoteClosedIdle { lifetime } => {
+            log::debug!("Remote closed an idle pooled socket after {:?}", lifetime);
+            sleep(RECONNECT_AFTER_IDLE_CLOSE).await;
+        }
+        // The local service is down; without a pause the whole pool would turn into a
+        // hot loop. This is the same 10 s that a local-connect error used to sleep for
+        // when it surfaced as a proxy error. Phase 3 replaces it with a local backoff.
+        ConnOutcome::LocalUnavailable => sleep(Duration::from_secs(10)).await,
+        ConnOutcome::RemoteConnectFailed => sleep(Duration::from_secs(10)).await,
+    }
+}
+
+fn set_remote_keepalive(stream: &TcpStream) -> Result<()> {
+    let ka = TcpKeepalive::new()
+        .with_time(TCP_KEEPALIVE_TIME)
+        .with_interval(TCP_KEEPALIVE_INTERVAL);
+    #[cfg(not(target_os = "windows"))]
+    let ka = ka.with_retries(TCP_KEEPALIVE_RETRIES);
+    let sf = SockRef::from(stream);
+    sf.set_tcp_keepalive(&ka)?;
+    Ok(())
+}
+
+/// Which half finished first, reported out of `select!` instead of acted on inside it.
+enum FirstDone {
+    RemoteToLocal(u64),
+    LocalToRemote(u64),
+    Failed(std::io::Error),
+}
+
+/// Splice the two streams with two half-copies, closing each write half explicitly
+/// once its source has reached EOF. Returns the total number of bytes moved.
+async fn splice_halves(remote_stream: &mut TcpStream, local_stream: &mut TcpStream) -> u64 {
+    // Borrowing `split()` rather than `into_split()`: ownership of both `TcpStream`s
+    // stays with the caller, there is no per-connection `Arc` allocation, and no
+    // implicit FIN from `Drop for OwnedWriteHalf`.
+    let (mut remote_reader, mut remote_writer) = remote_stream.split();
+    let (mut local_reader, mut local_writer) = local_stream.split();
+
+    // As long as both directions are alive neither `io::copy` ever completes, so
+    // `select!` does not fire and the grace timeout below is never even created — a
+    // silent-but-live websocket is not torn down by an idle period of any length.
+    // The grace window only starts counting after one side has already sent EOF.
+    let first = tokio::select! {
+        result = io::copy(&mut remote_reader, &mut local_writer) => match result {
+            Ok(bytes) => FirstDone::RemoteToLocal(bytes),
+            Err(err) => FirstDone::Failed(err),
+        },
+        result = io::copy(&mut local_reader, &mut remote_writer) => match result {
+            Ok(bytes) => FirstDone::LocalToRemote(bytes),
+            Err(err) => FirstDone::Failed(err),
+        },
+    };
+
+    // Only here are both futures dropped and the borrows on the halves released.
+    // Calling `shutdown()` inside a `select!` arm would not compile (E0499): the
+    // losing future still holds a `&mut` on its halves until the macro exits.
+    // `into_split()` does not change that, so switching split styles does not help.
+    // `io::copy` flushes on EOF but never shuts down, hence the explicit calls.
+    match first {
+        FirstDone::RemoteToLocal(bytes) => {
+            let _ = local_writer.shutdown().await;
+            let tail = timeout(
+                HALF_CLOSE_GRACE,
+                io::copy(&mut local_reader, &mut remote_writer),
+            )
+            .await;
+            let _ = remote_writer.shutdown().await;
+            bytes + tail.ok().and_then(|result| result.ok()).unwrap_or(0)
+        }
+        FirstDone::LocalToRemote(bytes) => {
+            let _ = remote_writer.shutdown().await;
+            let tail = timeout(
+                HALF_CLOSE_GRACE,
+                io::copy(&mut remote_reader, &mut local_writer),
+            )
+            .await;
+            let _ = local_writer.shutdown().await;
+            bytes + tail.ok().and_then(|result| result.ok()).unwrap_or(0)
+        }
+        FirstDone::Failed(err) => {
+            // The remote connection itself was established, so this is not a
+            // `RemoteConnectFailed`; it is just a connection that ended badly.
+            log::debug!("Proxy copy failed: {:?}", err);
+            let _ = local_writer.shutdown().await;
+            let _ = remote_writer.shutdown().await;
+            0
+        }
     }
 }
 
@@ -338,20 +482,63 @@ async fn proxy_through(
     mut remote_stream: TcpStream,
     local_host: &str,
     local_port: u16,
-) -> Result<()> {
+) -> Result<ConnOutcome> {
+    let opened_at = Instant::now();
+
+    // Keepalive goes on first, before anything else. This socket is about to sit in
+    // the server's pool with no local peer attached, waiting for a request that may
+    // never come; without keepalive a silently dropped NAT/firewall state would keep
+    // it hanging forever. It also covers the case where the local connect below
+    // disappears into a black hole (a SYN with no answer takes ~2 minutes on Linux).
+    set_remote_keepalive(&remote_stream)?;
+
+    // Wait for the first request byte with *no* connection to the local service. This
+    // is the fix for the stall: previously a FIN on an idle pooled socket never ended
+    // the task, because the bidirectional copy also waited for the live local
+    // keep-alive connection to reach EOF, so the semaphore permit leaked forever.
+    //
+    // No timeout here on purpose: a pooled socket is allowed to wait arbitrarily long,
+    // and a dead peer is detected by TCP keepalive (worst case 30 + 5x10 = 80 s).
+    // Adding a timeout here would break the server's connection pool.
+    let mut probe = [0u8; FIRST_BYTE_PROBE];
+    match remote_stream.peek(&mut probe).await {
+        Ok(0) => {
+            return Ok(ConnOutcome::RemoteClosedIdle {
+                lifetime: opened_at.elapsed(),
+            })
+        }
+        Err(err) => {
+            // RST, ConnectionReset or a keepalive TimedOut all mean the same thing to
+            // us: release the permit and reconnect. No need to split them apart.
+            log::debug!("Remote closed an idle socket: {:?}", err.kind());
+            return Ok(ConnOutcome::RemoteClosedIdle {
+                lifetime: opened_at.elapsed(),
+            });
+        }
+        Ok(_) => {}
+    }
+
     log::debug!("Connecting to local: {}:{}", local_host, local_port);
-    let mut local_stream = TcpStream::connect(format!("{local_host}:{local_port}")).await?;
+    let mut local_stream = match TcpStream::connect(format!("{local_host}:{local_port}")).await {
+        Ok(stream) => stream,
+        Err(err) => {
+            log::error!("Local connect failed: {:?}", err);
+            // Answer with a real HTTP error so the caller sees a 502 instead of an
+            // empty read. Content-Length must match the 21-byte body exactly, or the
+            // far end blocks waiting for the rest. Write errors are swallowed on
+            // purpose: the remote may already be gone, which is not worth logging.
+            let _ = remote_stream
+                .write_all(b"HTTP/1.1 502 Bad Gateway\r\nContent-Type: text/plain\r\nContent-Length: 21\r\nConnection: close\r\n\r\nlocal service is down")
+                .await;
+            let _ = remote_stream.shutdown().await;
+            return Ok(ConnOutcome::LocalUnavailable);
+        }
+    };
 
-    let ka = TcpKeepalive::new()
-        .with_time(TCP_KEEPALIVE_TIME)
-        .with_interval(TCP_KEEPALIVE_INTERVAL);
-    #[cfg(not(target_os = "windows"))]
-    let ka = ka.with_retries(TCP_KEEPALIVE_RETRIES);
-    let sf = SockRef::from(&remote_stream);
-    sf.set_tcp_keepalive(&ka)?;
-
-    io::copy_bidirectional(&mut remote_stream, &mut local_stream).await?;
-    Ok(())
+    // Nothing to replay: `peek` did not consume the probed bytes, they are still in
+    // the kernel receive buffer and the splice below picks them up on its first read.
+    let bytes = splice_halves(&mut remote_stream, &mut local_stream).await;
+    Ok(ConnOutcome::Served { bytes })
 }
 
 async fn get_tunnel_endpoint(

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -22,6 +22,18 @@ const TCP_KEEPALIVE_INTERVAL: Duration = Duration::from_secs(10);
 #[cfg(not(target_os = "windows"))]
 const TCP_KEEPALIVE_RETRIES: u32 = 5;
 
+/// Half-width of the reconnect jitter, in percent: a delay lands in [80 %, 120 %] of the
+/// exponential value, so a pool of connections that failed together does not retry in lockstep.
+const RECONNECT_JITTER_PERCENT: u64 = 20;
+/// Cap on the doubling exponent; `1u32 << 32` would overflow, and 2^31 already exceeds any cap.
+const BACKOFF_MAX_SHIFT: u32 = 31;
+/// Fibonacci-hashing constant: spreads adjacent task indices into far-apart PRNG states.
+const BACKOFF_SEED_MIX: u64 = 0x9E37_79B9_7F4A_7C15;
+/// xorshift64* output multiplier (Marsaglia); scrambles the low bits we take a modulo of.
+const BACKOFF_SCRAMBLE: u64 = 0x2545_F491_4F6C_DD1D;
+/// Keeps a task's local-failure sequence from coinciding with its remote-failure sequence.
+const LOCAL_BACKOFF_SEED_XOR: u64 = 0xA5A5_A5A5_A5A5_A5A5;
+
 /// How long a pooled socket must have survived before the remote closing it counts as
 /// ordinary pool recycling rather than an endpoint failure. A socket closed within this
 /// window never had a chance to carry a request: the server was restarting, its listener
@@ -45,15 +57,6 @@ const FIRST_BYTE_PROBE: usize = 1;
 /// both halves alive (a websocket, an SSE stream) is never affected by it: neither
 /// copy completes, so the grace timeout is not even created.
 const HALF_CLOSE_GRACE: Duration = Duration::from_secs(10);
-
-/// Pause before re-offering a socket after the remote closed an idle pooled one.
-/// This is a safety belt, not decoration: before this fix such a task hung forever,
-/// now it finishes in milliseconds, and without a pause `max_conn` tasks would spin
-/// in a hot reconnect loop while the endpoint keeps refusing sockets. 500 ms caps
-/// that at two attempts per second per task while still fitting inside the 5 s
-/// recovery window the regression test asserts. Phase 3 replaces this constant with
-/// exponential backoff plus deterministic jitter.
-const RECONNECT_AFTER_IDLE_CLOSE: Duration = Duration::from_millis(500);
 
 /// How a single tunnel connection ended.
 ///
@@ -82,11 +85,12 @@ enum ConnOutcome {
     RemoteConnectFailed,
 }
 
-/// Which reconnect delay a finished connection task should apply. Phase 2 only decides
-/// *which* counter is at fault; the actual delays still come from the hardcoded sleeps
-/// and are replaced by real exponential backoff in phase 3. Keeping remote and local
-/// apart matters because they have opposite tuning: a returning local service should be
-/// picked up in milliseconds, an unreachable endpoint should be retried ever more slowly.
+/// Which reconnect delay a finished connection task should apply. Deciding *which*
+/// counter is at fault is kept apart from deciding *how long* to wait: the connection
+/// task owns the two [`Backoff`] counters and turns this answer into a pause. Keeping
+/// remote and local apart matters because they have opposite tuning: a returning local
+/// service should be picked up in milliseconds, an unreachable endpoint should be
+/// retried ever more slowly.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum BackoffAction {
     /// The connection did its job — reset any backoff and reconnect at once.
@@ -105,6 +109,18 @@ enum BackoffAction {
 /// momentary network hiccup) that keepalive + reconnect can ride out on its own
 /// won't force a costly re-registration.
 pub const DEFAULT_REREGISTER_AFTER: Duration = Duration::from_secs(30);
+
+/// Default for [`ClientConfig::reconnect_base_delay`]: the pause before the first
+/// reconnect attempt after a failed connection. Small on purpose — a local service that
+/// was restarting is picked up in about half a second instead of the fixed ten seconds
+/// this replaces — while the exponential growth keeps a long outage cheap.
+pub const DEFAULT_RECONNECT_BASE_DELAY: Duration = Duration::from_millis(500);
+
+/// Default for [`ClientConfig::reconnect_max_delay`]: the ceiling the reconnect pause
+/// doubles up to. Thirty seconds keeps a service that has been down for an hour at two
+/// polls a minute, and stays below the server's own socket bookkeeping so a recovered
+/// endpoint is still noticed promptly.
+pub const DEFAULT_RECONNECT_MAX_DELAY: Duration = Duration::from_secs(30);
 
 #[derive(Debug, Serialize, Deserialize)]
 struct ProxyResponse {
@@ -134,6 +150,12 @@ pub struct ClientConfig {
     /// How long the remote endpoint must be continuously unreachable before the
     /// tunnel re-registers. `None` uses [`DEFAULT_REREGISTER_AFTER`].
     pub reregister_after: Option<Duration>,
+    /// Pause before the first reconnect attempt of a connection task; it doubles on every
+    /// consecutive failure. `None` uses [`DEFAULT_RECONNECT_BASE_DELAY`].
+    pub reconnect_base_delay: Option<Duration>,
+    /// Ceiling for the reconnect pause, jitter included. `None` uses
+    /// [`DEFAULT_RECONNECT_MAX_DELAY`].
+    pub reconnect_max_delay: Option<Duration>,
 }
 
 /// Open tunnels directly between server and localhost.
@@ -151,6 +173,8 @@ pub async fn open_tunnel(config: ClientConfig) -> Result<String> {
         max_conn,
         credential,
         reregister_after,
+        reconnect_base_delay,
+        reconnect_max_delay,
     } = config;
     let tunnel_info =
         get_tunnel_endpoint(server.clone(), subdomain.clone(), credential.clone()).await?;
@@ -165,10 +189,78 @@ pub async fn open_tunnel(config: ClientConfig) -> Result<String> {
         shutdown_signal,
         max_conn,
         reregister_after: reregister_after.unwrap_or(DEFAULT_REREGISTER_AFTER),
+        backoff: BackoffConfig {
+            base: reconnect_base_delay.unwrap_or(DEFAULT_RECONNECT_BASE_DELAY),
+            cap: reconnect_max_delay.unwrap_or(DEFAULT_RECONNECT_MAX_DELAY),
+        },
     };
     tokio::spawn(tunnel_supervisor(supervisor_config, tunnel_info));
 
     Ok(url)
+}
+
+/// Resolved reconnect timing, shared by every connection task of a round. Each task keeps
+/// its own attempt counters; only these bounds are common.
+#[derive(Clone, Copy, Debug)]
+struct BackoffConfig {
+    base: Duration,
+    cap: Duration,
+}
+
+/// Deterministic exponential backoff with +/-20 % jitter and no external RNG.
+///
+/// `seed` is the index of the connection task in the round: together with the attempt
+/// counter it yields a sequence that is reproducible (so tests are not flaky) yet
+/// decorrelated between tasks, which is the whole point of jitter — otherwise every
+/// connection in the pool would retry in the same instant.
+#[derive(Debug)]
+struct Backoff {
+    base: Duration,
+    cap: Duration,
+    attempt: u32,
+    rng: u64,
+}
+
+impl Backoff {
+    fn new(config: BackoffConfig, seed: u64) -> Self {
+        Self {
+            base: config.base,
+            cap: config.cap,
+            attempt: 0,
+            // `| 1` guarantees a non-zero state: xorshift is stuck forever at zero.
+            rng: seed.wrapping_mul(BACKOFF_SEED_MIX) | 1,
+        }
+    }
+
+    /// Back to the base delay after the endpoint proved healthy.
+    fn reset(&mut self) {
+        self.attempt = 0;
+    }
+
+    /// Next pause: exponential with a ceiling, then deterministic jitter. The ceiling is
+    /// applied a second time after jitter so the configured maximum is a hard maximum.
+    fn next_delay(&mut self) -> Duration {
+        let factor = 1u32
+            .checked_shl(self.attempt.min(BACKOFF_MAX_SHIFT))
+            .unwrap_or(u32::MAX);
+        let exponential = self.base.saturating_mul(factor).min(self.cap);
+        self.attempt = self.attempt.saturating_add(1);
+
+        let spread = 2 * RECONNECT_JITTER_PERCENT + 1;
+        let percent = (100 - RECONNECT_JITTER_PERCENT) + (self.next_u64() % spread);
+        let millis = (exponential.as_millis() as u64).saturating_mul(percent) / 100;
+        Duration::from_millis(millis).min(self.cap)
+    }
+
+    /// xorshift64* — deterministic, never leaves the zero state, no dependency.
+    fn next_u64(&mut self) -> u64 {
+        let mut x = self.rng;
+        x ^= x >> 12;
+        x ^= x << 25;
+        x ^= x >> 27;
+        self.rng = x;
+        x.wrapping_mul(BACKOFF_SCRAMBLE)
+    }
 }
 
 struct SupervisorConfig {
@@ -180,6 +272,7 @@ struct SupervisorConfig {
     shutdown_signal: broadcast::Sender<()>,
     max_conn: u8,
     reregister_after: Duration,
+    backoff: BackoffConfig,
 }
 
 // Runs the register → connect → detect-failures → re-register cycle.
@@ -210,6 +303,7 @@ async fn tunnel_supervisor(config: SupervisorConfig, initial_info: TunnelServerI
             round_stop_tx.clone(),
             config.max_conn,
             health,
+            config.backoff,
         );
 
         // Block until either the connections ask for re-registration or we
@@ -370,6 +464,7 @@ fn start_tunnel_connections(
     shutdown_signal: broadcast::Sender<()>,
     max_conn: u8,
     health: RoundHealth,
+    backoff_config: BackoffConfig,
 ) {
     let server_host = server.host.clone();
     let server_port = server.port;
@@ -382,6 +477,12 @@ fn start_tunnel_connections(
     let mut shutdown_receiver = shutdown_signal.subscribe();
 
     tokio::spawn(async move {
+        // Monotonic index of every connection task spawned in this round. It seeds the
+        // deterministic backoff jitter, so tasks that failed in the same instant do not
+        // retry in the same instant. There is no other source of per-task entropy: the
+        // client deliberately depends on no RNG crate.
+        let mut spawn_index: u64 = 0;
+
         loop {
             tokio::select! {
                 res = limit_connection.clone().acquire_owned() => {
@@ -396,14 +497,43 @@ fn start_tunnel_connections(
                     let local_host = local_host.clone();
                     let health = health.clone();
                     let mut shutdown_receiver = shutdown_signal.subscribe();
+                    let task_index = spawn_index;
+                    spawn_index = spawn_index.wrapping_add(1);
 
                     tokio::spawn(async move {
+                        let mut remote_backoff = Backoff::new(backoff_config, task_index);
+                        let mut local_backoff =
+                            Backoff::new(backoff_config, task_index ^ LOCAL_BACKOFF_SEED_XOR);
+
                         tokio::select! {
-                            _ = tunnel_one_connection(
-                                &server_host, server_port,
-                                &local_host, local_port,
-                                &health,
-                            ) => {}
+                            _ = async {
+                                // Retrying inside the task is what makes the delay able to grow:
+                                // the backoff state has to outlive a single attempt, otherwise a
+                                // service that has been down for an hour would still be polled at
+                                // the base rate. The pause is taken while holding the permit, so it
+                                // throttles the whole pool exactly like the fixed sleep it replaces.
+                                loop {
+                                    let delay = match tunnel_one_connection(
+                                        &server_host, server_port,
+                                        &local_host, local_port,
+                                        &health,
+                                    ).await {
+                                        // The endpoint carried traffic: hand the permit back so a
+                                        // fresh task takes this slot with a clean slate.
+                                        BackoffAction::None => break,
+                                        BackoffAction::Remote => remote_backoff.next_delay(),
+                                        // The remote handed us a request, so it is healthy; only the
+                                        // developer's application is down. Clear the remote counter
+                                        // and slow down the local one instead.
+                                        BackoffAction::Local => {
+                                            remote_backoff.reset();
+                                            local_backoff.next_delay()
+                                        }
+                                    };
+                                    log::debug!("Task {} reconnecting in {:?}", task_index, delay);
+                                    sleep(delay).await;
+                                }
+                            } => {}
                             _ = shutdown_receiver.recv() => {
                                 log::info!("Shutting down connection");
                             }
@@ -427,44 +557,29 @@ async fn tunnel_one_connection(
     local_host: &str,
     local_port: u16,
     health: &RoundHealth,
-) {
+) -> BackoffAction {
     log::debug!("Connecting to remote: {}:{}", server_host, server_port);
-    let outcome = match TcpStream::connect(format!("{server_host}:{server_port}")).await {
-        // A successful connect proves nothing on its own: the server may hand back a
-        // socket it is about to drop. Only the outcome of the connection moves health.
-        Ok(remote_stream) => match proxy_through(remote_stream, local_host, local_port).await {
-            Ok(outcome) => outcome,
-            // A genuine I/O error mid-splice still proves the remote was reachable, so it
-            // must not be charged to endpoint health; treat it as a local-side problem.
-            Err(err) => {
-                log::error!("Proxy error: {:?}", err);
-                ConnOutcome::LocalUnavailable
-            }
-        },
+    // A successful connect proves nothing on its own: the server may hand back a socket it
+    // is about to drop. Only the outcome of the connection moves health. Pacing is decided
+    // by the caller, which owns the per-task backoff state — this function never sleeps.
+    let remote_stream = match TcpStream::connect(format!("{server_host}:{server_port}")).await {
+        Ok(stream) => stream,
         Err(err) => {
             log::error!("Remote connect failed: {:?}", err);
-            ConnOutcome::RemoteConnectFailed
+            return health.record_outcome(&ConnOutcome::RemoteConnectFailed);
         }
     };
 
-    let action = health.record_outcome(&outcome);
-
-    // Accounting and pacing are deliberately decided separately. The delays below are
-    // unchanged from the previous phase: an endpoint that closes idle sockets must still
-    // be retried twice a second, because that is what refills the pool the moment it
-    // recovers. Waiting ten seconds here would pin every semaphore permit taken in
-    // `start_tunnel_connections` and leave the tunnel dead for the whole recovery window.
-    // `action` already separates a remote fault from a local one; the next phase turns
-    // that distinction into two independent exponential backoff counters and retires
-    // both constants below.
-    match outcome {
-        ConnOutcome::Served { .. } => {}
-        ConnOutcome::RemoteClosedIdle { .. } => sleep(RECONNECT_AFTER_IDLE_CLOSE).await,
-        ConnOutcome::LocalUnavailable | ConnOutcome::RemoteConnectFailed => {
-            log::debug!("Reconnect delayed after {:?}", action);
-            sleep(Duration::from_secs(10)).await
+    let outcome = match proxy_through(remote_stream, local_host, local_port).await {
+        Ok(outcome) => outcome,
+        // A genuine I/O error mid-splice still proves the remote was reachable, so it must
+        // not be charged to endpoint health; treat it as a local-side problem.
+        Err(err) => {
+            log::error!("Proxy error: {:?}", err);
+            ConnOutcome::LocalUnavailable
         }
-    }
+    };
+    health.record_outcome(&outcome)
 }
 
 fn set_remote_keepalive(stream: &TcpStream) -> Result<()> {
@@ -645,6 +760,116 @@ async fn get_tunnel_endpoint(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn test_backoff_config() -> BackoffConfig {
+        BackoffConfig {
+            base: Duration::from_millis(500),
+            cap: Duration::from_secs(30),
+        }
+    }
+
+    // The delay doubles on every consecutive failure, jitter included: each pause stays
+    // inside +/-20 % of 500 ms * 2^n.
+    //
+    // Compared in whole milliseconds on purpose: `next_delay` builds the jitter with
+    // integer arithmetic (`* percent / 100`), so at percent = 80 it lands exactly on the
+    // lower bound. A float bound written as `expected.mul_f64(0.8)` would make the assert
+    // depend on f64 rounding of that very same boundary.
+    #[test]
+    fn backoff_doubles_on_consecutive_failures() {
+        let mut backoff = Backoff::new(test_backoff_config(), 0);
+        for attempt in 0..6u32 {
+            let expected_millis = 500u128 << attempt;
+            let lower = expected_millis * 80 / 100;
+            let upper = expected_millis * 120 / 100;
+            let delay_millis = backoff.next_delay().as_millis();
+            assert!(
+                delay_millis >= lower && delay_millis <= upper,
+                "attempt {attempt}: {delay_millis} ms is outside [{lower}, {upper}] ms"
+            );
+        }
+    }
+
+    // Growth stops at the configured ceiling, and the ceiling is hard: jitter may only
+    // pull a capped delay down, never above the maximum a user configured.
+    #[test]
+    fn backoff_never_exceeds_the_cap() {
+        let config = test_backoff_config();
+        let mut backoff = Backoff::new(config, 7);
+        let mut last = Duration::ZERO;
+        for _ in 0..40 {
+            last = backoff.next_delay();
+            assert!(
+                last <= config.cap,
+                "delay {last:?} exceeded cap {:?}",
+                config.cap
+            );
+        }
+        // Same integer comparison as above: at percent = 80 the value lands exactly on
+        // 80 % of the cap, so the bound must not go through f64.
+        assert!(
+            last.as_millis() >= config.cap.as_millis() * 80 / 100,
+            "tail delay {last:?} should sit at the cap"
+        );
+    }
+
+    // A healthy endpoint puts the task back at the base delay.
+    #[test]
+    fn backoff_reset_returns_to_the_base_delay() {
+        let mut backoff = Backoff::new(test_backoff_config(), 3);
+        for _ in 0..8 {
+            backoff.next_delay();
+        }
+        backoff.reset();
+        let delay = backoff.next_delay();
+        assert!(
+            delay >= Duration::from_millis(400) && delay <= Duration::from_millis(600),
+            "after reset the delay must be back at the base, got {delay:?}"
+        );
+    }
+
+    // Jitter that is identically zero would let the whole pool reconnect in one burst,
+    // which is the only reason jitter exists here.
+    #[test]
+    fn backoff_jitter_is_not_identically_zero() {
+        let config = test_backoff_config();
+        let delays: std::collections::BTreeSet<Duration> = (0..16u64)
+            .map(|seed| Backoff::new(config, seed).next_delay())
+            .collect();
+        assert!(
+            delays.len() >= 2,
+            "16 task indices produced one single delay: {delays:?}"
+        );
+    }
+
+    // Two tasks of the same round must not walk the same sequence.
+    #[test]
+    fn backoff_decorrelates_neighbouring_task_indices() {
+        let config = test_backoff_config();
+        let first: Vec<Duration> = (0..4)
+            .map(|_| Backoff::new(config, 1).next_delay())
+            .collect();
+        let mut a = Backoff::new(config, 1);
+        let mut b = Backoff::new(config, 2);
+        let sequence_a: Vec<Duration> = (0..4).map(|_| a.next_delay()).collect();
+        let sequence_b: Vec<Duration> = (0..4).map(|_| b.next_delay()).collect();
+        assert_eq!(first.len(), 4, "sanity: the helper produced four samples");
+        assert_ne!(
+            sequence_a, sequence_b,
+            "task 1 and task 2 retry in lockstep: {sequence_a:?}"
+        );
+    }
+
+    // The remote and the local counter of the same task are independent sequences.
+    #[test]
+    fn backoff_separates_remote_and_local_seeds() {
+        let config = test_backoff_config();
+        let mut remote = Backoff::new(config, 5);
+        let mut local = Backoff::new(config, 5 ^ LOCAL_BACKOFF_SEED_XOR);
+        let remote_delays: Vec<Duration> = (0..4).map(|_| remote.next_delay()).collect();
+        let local_delays: Vec<Duration> = (0..4).map(|_| local.next_delay()).collect();
+        assert_ne!(remote_delays, local_delays);
+    }
 
     // A connection that was alive while the tunnel sat idle, then dropped, must
     // not be reported as a long outage: refreshing health when the connection

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -22,6 +22,17 @@ const TCP_KEEPALIVE_INTERVAL: Duration = Duration::from_secs(10);
 #[cfg(not(target_os = "windows"))]
 const TCP_KEEPALIVE_RETRIES: u32 = 5;
 
+/// How long a pooled socket must have survived before the remote closing it counts as
+/// ordinary pool recycling rather than an endpoint failure. A socket closed within this
+/// window never had a chance to carry a request: the server was restarting, its listener
+/// was gone, or it refused the socket outright (`Reached sockets max` in
+/// `server/src/state.rs`). A socket the server held for longer and then closed is
+/// indistinguishable from a normal lifecycle event — a redeploy, the subdomain entry
+/// being replaced, an idle timeout on a load balancer in front of it — and must not
+/// force a re-registration. 5 s is short enough that a dead endpoint is detected within
+/// one reconnect cycle, and long enough that no healthy pool ever falls under it.
+const IDLE_CLOSE_MIN_LIFETIME: Duration = Duration::from_secs(5);
+
 /// Size of the buffer used to wait for the first byte of a request. One byte is
 /// enough because the read is a *detector* ("data arrived" vs "FIN arrived"), not
 /// a parser — the bytes are peeked, not consumed, and the splice reads them again.
@@ -69,6 +80,22 @@ enum ConnOutcome {
     /// The TCP connect to the endpoint itself failed. Produced by
     /// `tunnel_one_connection`, not by `proxy_through`.
     RemoteConnectFailed,
+}
+
+/// Which reconnect delay a finished connection task should apply. Phase 2 only decides
+/// *which* counter is at fault; the actual delays still come from the hardcoded sleeps
+/// and are replaced by real exponential backoff in phase 3. Keeping remote and local
+/// apart matters because they have opposite tuning: a returning local service should be
+/// picked up in milliseconds, an unreachable endpoint should be retried ever more slowly.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BackoffAction {
+    /// The connection did its job — reset any backoff and reconnect at once.
+    None,
+    /// The remote endpoint is at fault. Back off the remote-side counter.
+    Remote,
+    /// The remote endpoint is fine, the local application is not. Back off the
+    /// local-side counter; endpoint health is untouched.
+    Local,
 }
 
 /// Default for [`ClientConfig::reregister_after`]: how long the remote endpoint
@@ -240,20 +267,24 @@ async fn tunnel_supervisor(config: SupervisorConfig, initial_info: TunnelServerI
 /// Tracks remote-endpoint health for a single round and triggers re-registration
 /// once the endpoint has been *continuously* unreachable for `reregister_after`.
 ///
-/// Only *remote* TCP-connect outcomes are recorded here: a failure means the
-/// server's listener port may be gone (cleanup, restart, etc.). Local-connect or
-/// proxy errors (e.g. local server restarting) are deliberately not recorded,
-/// avoiding spurious re-registration loops.
+/// Health is recorded from the *outcome* of a connection, never from the mere fact that a
+/// TCP connect succeeded: an endpoint that accepts a socket and closes it a moment later
+/// is unusable, and counting that accept as a success would refresh the timestamp forever
+/// so the trigger could never fire. Evidence of health is therefore traffic actually
+/// served, or a pooled socket the remote kept for at least `IDLE_CLOSE_MIN_LIFETIME`
+/// before closing it. Local-connect or proxy errors (e.g. the local server restarting)
+/// are deliberately not recorded as failures — the remote is fine, only the developer's
+/// application is down — and drive their own backoff instead, avoiding spurious
+/// re-registration loops.
 ///
-/// `last_success_ms` is the millisecond offset (from `round_start`) of the last
-/// time the remote was known reachable, shared across all connections in the
-/// round. It is refreshed both when a connection is established *and* when an
-/// established connection ends — a live connection proves the remote was
-/// reachable for as long as it lasted, so downtime is measured from when it
-/// dropped, not from when it opened (which may be long ago for an idle tunnel).
-/// Initialized to 0, i.e. "healthy at round start", so a never-reachable endpoint
-/// still trips after `reregister_after`. Tracking time rather than a failure count
-/// decouples the trigger from how many connections happen to fail at once.
+/// `last_success_ms` is the millisecond offset (from `round_start`) of the last time the
+/// remote was known usable, shared across all connections in the round. It is refreshed
+/// when a connection ends after proving the remote was usable — a live connection proves
+/// reachability for as long as it lasted, so downtime is measured from when it dropped,
+/// not from when it opened (which may be long ago for an idle tunnel). Initialized to 0,
+/// i.e. "healthy at round start", so a never-usable endpoint still trips after
+/// `reregister_after`. Tracking time rather than a failure count decouples the trigger
+/// from how many connections happen to fail at once.
 #[derive(Clone)]
 struct RoundHealth {
     round_start: Instant,
@@ -288,6 +319,47 @@ impl RoundHealth {
             let _ = self.reregister_tx.try_send(());
         }
         Duration::from_millis(down_for_ms)
+    }
+
+    /// Fold a finished connection's outcome into endpoint health and report which
+    /// reconnect delay the caller should apply.
+    ///
+    /// Only the remote endpoint's own behaviour moves the health timestamp. A socket the
+    /// remote accepted and then closed before it could carry anything is a failure even
+    /// though the TCP connect succeeded; a socket it kept for a while and then closed is
+    /// ordinary recycling. A local outage is never charged to the endpoint.
+    fn record_outcome(&self, outcome: &ConnOutcome) -> BackoffAction {
+        match outcome {
+            ConnOutcome::Served { bytes } => {
+                log::debug!("Connection served {} bytes", bytes);
+                self.record_success();
+                BackoffAction::None
+            }
+            ConnOutcome::RemoteConnectFailed => {
+                let down_for = self.record_failure();
+                log::warn!("Remote endpoint unreachable (down for {:?})", down_for);
+                BackoffAction::Remote
+            }
+            ConnOutcome::RemoteClosedIdle { lifetime } if *lifetime < IDLE_CLOSE_MIN_LIFETIME => {
+                let down_for = self.record_failure();
+                log::warn!(
+                    "Remote closed an idle socket after {:?} (down for {:?})",
+                    lifetime,
+                    down_for
+                );
+                BackoffAction::Remote
+            }
+            ConnOutcome::RemoteClosedIdle { lifetime } => {
+                log::debug!("Remote recycled an idle socket after {:?}", lifetime);
+                self.record_success();
+                BackoffAction::None
+            }
+            ConnOutcome::LocalUnavailable => {
+                log::error!("Local service unavailable, remote endpoint left untouched");
+                self.record_success();
+                BackoffAction::Local
+            }
+        }
     }
 }
 
@@ -358,44 +430,40 @@ async fn tunnel_one_connection(
 ) {
     log::debug!("Connecting to remote: {}:{}", server_host, server_port);
     let outcome = match TcpStream::connect(format!("{server_host}:{server_port}")).await {
-        Ok(stream) => {
-            health.record_success();
-            let proxy_result = proxy_through(stream, local_host, local_port).await;
-            // The remote stayed reachable for the whole life of this connection, which
-            // just ended. Refresh the timestamp so that if reconnects now start failing,
-            // downtime is measured from this moment rather than from when the connection
-            // was first opened — otherwise an idle tunnel that drops would report a huge
-            // downtime on the very first failure and re-register on a momentary blip.
-            health.record_success();
-            match proxy_result {
-                Ok(outcome) => outcome,
-                Err(err) => {
-                    log::error!("Proxy error: {:?}", err);
-                    sleep(Duration::from_secs(10)).await;
-                    return;
-                }
+        // A successful connect proves nothing on its own: the server may hand back a
+        // socket it is about to drop. Only the outcome of the connection moves health.
+        Ok(remote_stream) => match proxy_through(remote_stream, local_host, local_port).await {
+            Ok(outcome) => outcome,
+            // A genuine I/O error mid-splice still proves the remote was reachable, so it
+            // must not be charged to endpoint health; treat it as a local-side problem.
+            Err(err) => {
+                log::error!("Proxy error: {:?}", err);
+                ConnOutcome::LocalUnavailable
             }
-        }
+        },
         Err(err) => {
-            let down_for = health.record_failure();
-            log::error!("Remote connect failed (down for {:?}): {:?}", down_for, err);
+            log::error!("Remote connect failed: {:?}", err);
             ConnOutcome::RemoteConnectFailed
         }
     };
 
+    let action = health.record_outcome(&outcome);
+
+    // Accounting and pacing are deliberately decided separately. The delays below are
+    // unchanged from the previous phase: an endpoint that closes idle sockets must still
+    // be retried twice a second, because that is what refills the pool the moment it
+    // recovers. Waiting ten seconds here would pin every semaphore permit taken in
+    // `start_tunnel_connections` and leave the tunnel dead for the whole recovery window.
+    // `action` already separates a remote fault from a local one; the next phase turns
+    // that distinction into two independent exponential backoff counters and retires
+    // both constants below.
     match outcome {
-        ConnOutcome::Served { bytes } => {
-            log::debug!("Tunnel connection served {} bytes", bytes);
+        ConnOutcome::Served { .. } => {}
+        ConnOutcome::RemoteClosedIdle { .. } => sleep(RECONNECT_AFTER_IDLE_CLOSE).await,
+        ConnOutcome::LocalUnavailable | ConnOutcome::RemoteConnectFailed => {
+            log::debug!("Reconnect delayed after {:?}", action);
+            sleep(Duration::from_secs(10)).await
         }
-        ConnOutcome::RemoteClosedIdle { lifetime } => {
-            log::debug!("Remote closed an idle pooled socket after {:?}", lifetime);
-            sleep(RECONNECT_AFTER_IDLE_CLOSE).await;
-        }
-        // The local service is down; without a pause the whole pool would turn into a
-        // hot loop. This is the same 10 s that a local-connect error used to sleep for
-        // when it surfaced as a proxy error. Phase 3 replaces it with a local backoff.
-        ConnOutcome::LocalUnavailable => sleep(Duration::from_secs(10)).await,
-        ConnOutcome::RemoteConnectFailed => sleep(Duration::from_secs(10)).await,
     }
 }
 
@@ -612,5 +680,160 @@ mod tests {
         let down = health.record_failure();
         assert!(down >= Duration::from_millis(200), "downtime was {down:?}");
         assert!(rx.try_recv().is_ok(), "should request re-registration");
+    }
+
+    // A connection that actually carried traffic is the strongest possible proof that
+    // the endpoint is alive, so it clears any accumulated downtime and asks for no delay.
+    #[tokio::test]
+    async fn served_connection_marks_endpoint_healthy() {
+        let (tx, mut rx) = mpsc::channel(1);
+        let health = RoundHealth::new(Duration::from_millis(200), tx);
+
+        sleep(Duration::from_millis(250)).await; // past the window
+        let action = health.record_outcome(&ConnOutcome::Served { bytes: 42 });
+
+        assert_eq!(
+            action,
+            BackoffAction::None,
+            "served traffic needs no backoff"
+        );
+        assert!(
+            rx.try_recv().is_err(),
+            "a served connection must not re-register"
+        );
+        let down = health.record_failure();
+        assert!(down < Duration::from_millis(200), "downtime was {down:?}");
+    }
+
+    // A refused TCP connect is the classic "the listener is gone" signal and is the one
+    // case that already worked before phase 2; it must keep working.
+    #[tokio::test]
+    async fn remote_connect_failure_counts_against_the_endpoint() {
+        let (tx, mut rx) = mpsc::channel(1);
+        let health = RoundHealth::new(Duration::from_millis(200), tx);
+
+        sleep(Duration::from_millis(250)).await;
+        let action = health.record_outcome(&ConnOutcome::RemoteConnectFailed);
+
+        assert_eq!(
+            action,
+            BackoffAction::Remote,
+            "a dead endpoint needs remote backoff"
+        );
+        assert!(
+            rx.try_recv().is_ok(),
+            "sustained connect failures must re-register"
+        );
+    }
+
+    // The defect this phase exists for: the server accepts the socket and drops it right
+    // away, so `TcpStream::connect` succeeds and nothing used to be recorded. A socket
+    // closed this fast never had a chance to serve anything — it is an endpoint failure.
+    #[tokio::test]
+    async fn instant_remote_close_counts_as_endpoint_failure() {
+        let (tx, mut rx) = mpsc::channel(1);
+        let health = RoundHealth::new(Duration::from_millis(200), tx);
+
+        sleep(Duration::from_millis(250)).await;
+        let action = health.record_outcome(&ConnOutcome::RemoteClosedIdle {
+            lifetime: Duration::from_millis(1),
+        });
+
+        assert_eq!(
+            action,
+            BackoffAction::Remote,
+            "an instant close is a failure"
+        );
+        assert!(
+            rx.try_recv().is_ok(),
+            "instant closes must arm re-registration"
+        );
+    }
+
+    // The opposite end of the same variant: a socket the server held for a while and then
+    // closed is ordinary recycling (redeploy, subdomain entry replaced, LB idle timeout).
+    // Charging it to the endpoint would re-register a perfectly healthy tunnel. The
+    // threshold is inclusive, so a lifetime exactly at the boundary counts as healthy.
+    #[tokio::test]
+    async fn long_lived_remote_close_is_normal_pool_recycling() {
+        let (tx, mut rx) = mpsc::channel(1);
+        let health = RoundHealth::new(Duration::from_millis(200), tx);
+
+        sleep(Duration::from_millis(250)).await;
+        let action = health.record_outcome(&ConnOutcome::RemoteClosedIdle {
+            lifetime: IDLE_CLOSE_MIN_LIFETIME,
+        });
+
+        assert_eq!(
+            action,
+            BackoffAction::None,
+            "pool recycling needs no remote backoff"
+        );
+        assert!(
+            rx.try_recv().is_err(),
+            "pool recycling must not re-register"
+        );
+    }
+
+    // A local outage says nothing about the remote endpoint; re-registering would move
+    // the listener for no reason and loop for as long as the developer's service is down.
+    // Repeating it well past the window must still leave the endpoint marked healthy.
+    #[tokio::test]
+    async fn local_outage_never_reregisters() {
+        let (tx, mut rx) = mpsc::channel(1);
+        let health = RoundHealth::new(Duration::from_millis(200), tx);
+
+        for _ in 0..3 {
+            sleep(Duration::from_millis(100)).await;
+            let action = health.record_outcome(&ConnOutcome::LocalUnavailable);
+            assert_eq!(
+                action,
+                BackoffAction::Local,
+                "local outages back off locally"
+            );
+        }
+
+        assert!(
+            rx.try_recv().is_err(),
+            "a local outage must never trigger re-registration, however long it lasts",
+        );
+    }
+
+    // Guards the load-bearing decision of plan 02-02: a successful TCP connect is no
+    // longer evidence of health. Nothing inside an instant-close loop may refresh
+    // `last_success_ms`, otherwise downtime is wiped on every iteration and the trigger
+    // can never fire — which is precisely why the tunnel stayed dead in issue #8. Unlike
+    // the tests above, the window here cannot be cleared by a single step, so the
+    // accumulation itself is exercised rather than assumed.
+    #[tokio::test]
+    async fn repeated_instant_closes_accumulate_downtime() {
+        let (tx, mut rx) = mpsc::channel(1);
+        let health = RoundHealth::new(Duration::from_millis(500), tx);
+
+        for _ in 0..2 {
+            sleep(Duration::from_millis(100)).await;
+            let action = health.record_outcome(&ConnOutcome::RemoteClosedIdle {
+                lifetime: Duration::from_millis(1),
+            });
+            assert_eq!(
+                action,
+                BackoffAction::Remote,
+                "instant closes back off remotely"
+            );
+            assert!(
+                rx.try_recv().is_err(),
+                "downtime is still inside the window"
+            );
+        }
+
+        sleep(Duration::from_millis(400)).await;
+        health.record_outcome(&ConnOutcome::RemoteClosedIdle {
+            lifetime: Duration::from_millis(1),
+        });
+
+        assert!(
+            rx.try_recv().is_ok(),
+            "instant closes must accumulate downtime, not reset it on every attempt",
+        );
     }
 }

--- a/client/tests/instant_close_reregistration.rs
+++ b/client/tests/instant_close_reregistration.rs
@@ -1,0 +1,214 @@
+use std::sync::{
+    atomic::{AtomicU16, AtomicU32, Ordering},
+    Arc,
+};
+
+use localtunnel_client::{broadcast, open_tunnel, ClientConfig};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+use tokio::time::{sleep, Duration, Instant};
+
+// Same mock API as `reregistration.rs`, plus a request counter: re-registration is
+// observable only as "the client asked the API for an endpoint again".
+async fn mock_api_server(
+    listener: TcpListener,
+    endpoint_port: Arc<AtomicU16>,
+    requests: Arc<AtomicU32>,
+) {
+    loop {
+        let (mut stream, _) = match listener.accept().await {
+            Ok(value) => value,
+            Err(_) => return,
+        };
+        let mut buf = [0u8; 4096];
+        let _ = stream.read(&mut buf).await;
+        requests.fetch_add(1, Ordering::Relaxed);
+
+        let port = endpoint_port.load(Ordering::Relaxed);
+        let body = format!(
+            r#"{{"id":"test","port":{port},"max_conn_count":10,"url":"http://test.127.0.0.1:{port}"}}"#,
+        );
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+            body.len(),
+        );
+        let _ = stream.write_all(response.as_bytes()).await;
+    }
+}
+
+// Remote endpoint that accepts and immediately drops every socket: this is what a
+// restarting server, and the `Reached sockets max` path in `server/src/state.rs`,
+// look like from the client side.
+async fn accept_and_close(listener: TcpListener, accepted: Arc<AtomicU32>) {
+    loop {
+        match listener.accept().await {
+            Ok((stream, _)) => {
+                accepted.fetch_add(1, Ordering::Relaxed);
+                drop(stream);
+            }
+            Err(_) => return,
+        }
+    }
+}
+
+// Healthy remote endpoint: it holds every pooled socket and, once `poke_after` has
+// elapsed, pushes a minimal HTTP request into each one. That is what forces the client
+// to dial the (absent) local service, i.e. it is the only way to exercise
+// `LocalUnavailable` now that the local connect is lazy.
+async fn accept_hold_and_poke(
+    listener: TcpListener,
+    accepted: Arc<AtomicU32>,
+    poke_after: Duration,
+) {
+    let mut held = Vec::new();
+    let mut poke_at = Instant::now() + poke_after;
+    loop {
+        tokio::select! {
+            incoming = listener.accept() => {
+                match incoming {
+                    Ok((stream, _)) => {
+                        accepted.fetch_add(1, Ordering::Relaxed);
+                        held.push(stream);
+                    }
+                    Err(_) => return,
+                }
+            }
+            _ = tokio::time::sleep_until(poke_at) => {
+                for stream in held.iter_mut() {
+                    let _ = stream.write_all(b"GET / HTTP/1.1\r\nHost: test\r\n\r\n").await;
+                }
+                // Poke exactly once; push the deadline far out so the arm stops firing.
+                poke_at = Instant::now() + Duration::from_secs(3600);
+            }
+        }
+    }
+}
+
+// A remote endpoint that accepts and instantly closes every socket is *not* a healthy
+// endpoint: the tunnel can never carry traffic through it. Until the outcome of a
+// connection feeds back into `RoundHealth`, `record_failure()` is never reached (the
+// TCP connect itself succeeds), so the re-registration timer never arms and the tunnel
+// stays dead — exactly the "restarting the service doesn't help" report in issue #8.
+#[tokio::test(flavor = "multi_thread")]
+async fn reregisters_when_remote_closes_every_socket() {
+    let remote = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let remote_port = remote.local_addr().unwrap().port();
+    let remote_accepted = Arc::new(AtomicU32::new(0));
+    tokio::spawn(accept_and_close(remote, remote_accepted.clone()));
+
+    // No local service is needed: the remote never delivers a request byte.
+    let dead_local = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let local_port = dead_local.local_addr().unwrap().port();
+    drop(dead_local);
+
+    let api_requests = Arc::new(AtomicU32::new(0));
+    let api = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let api_port = api.local_addr().unwrap().port();
+    tokio::spawn(mock_api_server(
+        api,
+        Arc::new(AtomicU16::new(remote_port)),
+        api_requests.clone(),
+    ));
+
+    // `Duration::ZERO` makes the very first recorded failure trip the re-registration
+    // window, the same trick `reregistration.rs` uses: the test must never wait for
+    // a product constant (30 s window, 10 s reconnect sleep). The windowing arithmetic
+    // itself is covered by the unit tests in `client/src/lib.rs`.
+    let (shutdown_tx, _) = broadcast::channel(1);
+    let config = ClientConfig {
+        server: Some(format!("http://127.0.0.1:{api_port}")),
+        subdomain: Some("test".to_string()),
+        local_host: Some("127.0.0.1".to_string()),
+        local_port,
+        shutdown_signal: shutdown_tx.clone(),
+        max_conn: 10,
+        credential: None,
+        reregister_after: Some(Duration::ZERO),
+    };
+    open_tunnel(config).await.unwrap();
+
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while remote_accepted.load(Ordering::Relaxed) == 0 {
+            sleep(Duration::from_millis(50)).await;
+        }
+    })
+    .await
+    .expect("client should offer at least one socket to the remote endpoint");
+
+    let outcome = tokio::time::timeout(Duration::from_secs(10), async {
+        while api_requests.load(Ordering::Relaxed) < 2 {
+            sleep(Duration::from_millis(50)).await;
+        }
+    })
+    .await;
+
+    let _ = shutdown_tx.send(());
+    outcome.expect(
+        "an endpoint that accepts and instantly closes every socket must be treated as \
+         unreachable and trigger re-registration",
+    );
+}
+
+// The mirror image: the remote endpoint is perfectly healthy, only the local
+// application is down. Re-registering would move the public URL's listener for no
+// reason and would loop forever while the developer restarts their service, so a local
+// outage must never be charged to the remote endpoint — see the doc comment on
+// `RoundHealth` in `client/src/lib.rs`.
+#[tokio::test(flavor = "multi_thread")]
+async fn local_outage_does_not_trigger_reregistration() {
+    // Bind then drop: a port nothing listens on, i.e. the local service is down.
+    let dead_local = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let local_port = dead_local.local_addr().unwrap().port();
+    drop(dead_local);
+
+    let remote = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let remote_port = remote.local_addr().unwrap().port();
+    let remote_accepted = Arc::new(AtomicU32::new(0));
+    // Poke after 400 ms — well past the 200 ms re-registration window below, so a
+    // mis-classified `LocalUnavailable` would trip the trigger and fail this test.
+    tokio::spawn(accept_hold_and_poke(
+        remote,
+        remote_accepted.clone(),
+        Duration::from_millis(400),
+    ));
+
+    let api_requests = Arc::new(AtomicU32::new(0));
+    let api = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let api_port = api.local_addr().unwrap().port();
+    tokio::spawn(mock_api_server(
+        api,
+        Arc::new(AtomicU16::new(remote_port)),
+        api_requests.clone(),
+    ));
+
+    let (shutdown_tx, _) = broadcast::channel(1);
+    let config = ClientConfig {
+        server: Some(format!("http://127.0.0.1:{api_port}")),
+        subdomain: Some("test".to_string()),
+        local_host: Some("127.0.0.1".to_string()),
+        local_port,
+        shutdown_signal: shutdown_tx.clone(),
+        max_conn: 10,
+        credential: None,
+        reregister_after: Some(Duration::from_millis(200)),
+    };
+    open_tunnel(config).await.unwrap();
+
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while remote_accepted.load(Ordering::Relaxed) == 0 {
+            sleep(Duration::from_millis(50)).await;
+        }
+    })
+    .await
+    .expect("client should offer sockets to the healthy remote endpoint");
+
+    // Let the poke land and the client fail its local connect several times over.
+    sleep(Duration::from_secs(2)).await;
+    let requests = api_requests.load(Ordering::Relaxed);
+    let _ = shutdown_tx.send(());
+
+    assert_eq!(
+        requests, 1,
+        "a local-service outage must not re-register the remote endpoint, got {requests} API requests",
+    );
+}

--- a/client/tests/instant_close_reregistration.rs
+++ b/client/tests/instant_close_reregistration.rs
@@ -124,6 +124,8 @@ async fn reregisters_when_remote_closes_every_socket() {
         max_conn: 10,
         credential: None,
         reregister_after: Some(Duration::ZERO),
+        reconnect_base_delay: None,
+        reconnect_max_delay: None,
     };
     open_tunnel(config).await.unwrap();
 
@@ -191,6 +193,8 @@ async fn local_outage_does_not_trigger_reregistration() {
         max_conn: 10,
         credential: None,
         reregister_after: Some(Duration::from_millis(200)),
+        reconnect_base_delay: None,
+        reconnect_max_delay: None,
     };
     open_tunnel(config).await.unwrap();
 

--- a/client/tests/local_restart_e2e.rs
+++ b/client/tests/local_restart_e2e.rs
@@ -1,0 +1,162 @@
+use localtunnel_client::{broadcast, open_tunnel, ClientConfig};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::task::JoinHandle;
+use tokio::time::{sleep, timeout, Duration};
+
+/// A minimal HTTP/1.1 server answering `200 OK` with `tag` as the body, so the
+/// test can tell the original process apart from the restarted one. The returned
+/// handle is what makes the restart observable: aborting it stops the accept loop
+/// the way killing the tunneled service would.
+async fn local_http(port: u16, tag: &'static str) -> JoinHandle<()> {
+    let listener = TcpListener::bind(("127.0.0.1", port)).await.unwrap();
+    tokio::spawn(async move {
+        loop {
+            let (mut stream, _) = match listener.accept().await {
+                Ok(value) => value,
+                Err(_) => return,
+            };
+            tokio::spawn(async move {
+                let mut buffer = [0u8; 4096];
+                loop {
+                    match stream.read(&mut buffer).await {
+                        Ok(0) | Err(_) => return,
+                        Ok(_) => {
+                            let response = format!(
+                                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\n\r\n{tag}",
+                                tag.len(),
+                            );
+                            if stream.write_all(response.as_bytes()).await.is_err() {
+                                return;
+                            }
+                        }
+                    }
+                }
+            });
+        }
+    })
+}
+
+/// Issues a request through the public side of the tunnel and returns the status
+/// line and the body joined together, so a single `contains` covers both. Errors
+/// are folded into the string rather than panicking: while the local service is
+/// down every outcome here is legitimate, and the caller decides what to assert.
+async fn proxy_get(proxy_port: u16, host: &str) -> String {
+    let mut stream = match TcpStream::connect(("127.0.0.1", proxy_port)).await {
+        Ok(stream) => stream,
+        Err(err) => return format!("CONNECT_ERR {err}"),
+    };
+    let request = format!("GET / HTTP/1.1\r\nHost: {host}\r\nConnection: close\r\n\r\n");
+    if stream.write_all(request.as_bytes()).await.is_err() {
+        return "WRITE_ERR".to_string();
+    }
+
+    let mut raw = String::new();
+    let _ = timeout(Duration::from_secs(5), stream.read_to_string(&mut raw)).await;
+    let status_line = raw.lines().next().unwrap_or("EMPTY").to_string();
+    let body = raw.rsplit("\r\n\r\n").next().unwrap_or("");
+    format!("{status_line} | {body}")
+}
+
+fn free_port() -> u16 {
+    std::net::TcpListener::bind("127.0.0.1:0")
+        .unwrap()
+        .local_addr()
+        .unwrap()
+        .port()
+}
+
+// End-to-end non-regression test for the scenario issue #8 is named after, run
+// against a real localtunnel-server rather than a mock: restart the tunneled
+// service and the public URL must serve it again.
+//
+// This test is green on f86f32b too — the simple case already worked there. It
+// exists because phases 1-3 rewrote the whole connection path (lazy local
+// connect, half-close handling, reconnect backoff) and none of that is allowed
+// to break the one scenario the issue actually reports. It runs on the shipped
+// defaults on purpose: `reconnect_base_delay` and `reconnect_max_delay` are left
+// `None` so the measured recovery is the one a real user gets.
+//
+// The server runs on its own thread with its own runtime because
+// `actix_web::HttpServer` is not `Send`, so `tokio::spawn` will not take it.
+#[tokio::test(flavor = "multi_thread")]
+async fn local_service_restart_is_served_again() {
+    let api_port = free_port();
+    let proxy_port = free_port();
+    let local_port = free_port();
+
+    std::thread::spawn(move || {
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        runtime.block_on(async move {
+            let _ = localtunnel_server::start(localtunnel_server::ServerConfig {
+                domain: format!("127.0.0.1:{proxy_port}"),
+                api_port,
+                secure: false,
+                max_sockets: 10,
+                proxy_port,
+                require_auth: false,
+            })
+            .await;
+        });
+    });
+
+    timeout(Duration::from_secs(10), async {
+        while TcpStream::connect(("127.0.0.1", api_port)).await.is_err() {
+            sleep(Duration::from_millis(50)).await;
+        }
+    })
+    .await
+    .expect("localtunnel-server should come up");
+
+    let first = local_http(local_port, "V1").await;
+
+    let (shutdown_tx, _) = broadcast::channel(1);
+    let url = open_tunnel(ClientConfig {
+        server: Some(format!("http://127.0.0.1:{api_port}")),
+        subdomain: Some("test".to_string()),
+        local_host: Some("127.0.0.1".to_string()),
+        local_port,
+        shutdown_signal: shutdown_tx.clone(),
+        max_conn: 10,
+        credential: None,
+        reregister_after: None,
+        reconnect_base_delay: None,
+        reconnect_max_delay: None,
+    })
+    .await
+    .unwrap();
+    println!("tunnel url = {url}");
+    sleep(Duration::from_secs(1)).await;
+
+    let host = format!("test.127.0.0.1:{proxy_port}");
+    let before = proxy_get(proxy_port, &host).await;
+    assert!(
+        before.contains("200 OK") && before.contains("V1"),
+        "the tunnel must serve the local service before the restart, got: {before}"
+    );
+
+    // Kill the tunneled service. What the tunnel answers while it is down is not
+    // asserted here — phase 1 covers the 502 — because pinning it down would make
+    // this test brittle for no extra coverage.
+    first.abort();
+    sleep(Duration::from_millis(300)).await;
+    println!("while down: {}", proxy_get(proxy_port, &host).await);
+
+    // Restart it on the same port, as a service restart would.
+    let restarted = local_http(local_port, "V2").await;
+    let recovered = timeout(Duration::from_secs(10), async {
+        loop {
+            let response = proxy_get(proxy_port, &host).await;
+            if response.contains("200 OK") && response.contains("V2") {
+                return response;
+            }
+            sleep(Duration::from_millis(200)).await;
+        }
+    })
+    .await
+    .expect("the tunnel must serve the restarted local service again");
+    assert!(recovered.contains("V2"), "unexpected body: {recovered}");
+
+    let _ = shutdown_tx.send(());
+    drop(restarted);
+}

--- a/client/tests/proxy_half_close.rs
+++ b/client/tests/proxy_half_close.rs
@@ -1,0 +1,202 @@
+use std::sync::{
+    atomic::{AtomicU16, Ordering},
+    Arc,
+};
+
+use localtunnel_client::{broadcast, open_tunnel, ClientConfig};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::mpsc;
+use tokio::time::{sleep, Duration};
+
+async fn mock_api_server(listener: TcpListener, endpoint_port: Arc<AtomicU16>) {
+    loop {
+        let (mut stream, _) = match listener.accept().await {
+            Ok(v) => v,
+            Err(_) => return,
+        };
+        let mut buf = [0u8; 4096];
+        let _ = stream.read(&mut buf).await;
+
+        let port = endpoint_port.load(Ordering::Relaxed);
+        let body = format!(
+            r#"{{"id":"test","port":{port},"max_conn_count":10,"url":"http://test.127.0.0.1:{port}"}}"#,
+        );
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+            body.len(),
+        );
+        let _ = stream.write_all(response.as_bytes()).await;
+    }
+}
+
+// Hands every socket the client offers over to the test body, which then plays the
+// role of the browser whose request the server pushed into the tunnel.
+async fn pooling_remote(listener: TcpListener, sockets: mpsc::Sender<TcpStream>) {
+    loop {
+        let (stream, _) = match listener.accept().await {
+            Ok(v) => v,
+            Err(_) => return,
+        };
+        if sockets.send(stream).await.is_err() {
+            return;
+        }
+    }
+}
+
+// A port nobody listens on: bind, read the port, drop the listener.
+fn free_port() -> u16 {
+    std::net::TcpListener::bind("127.0.0.1:0")
+        .unwrap()
+        .local_addr()
+        .unwrap()
+        .port()
+}
+
+// Echoes back whatever it reads and never closes the connection. Models a websocket
+// peer: both halves stay alive for the whole life of the connection.
+async fn local_echo(listener: TcpListener) {
+    loop {
+        let (mut stream, _) = match listener.accept().await {
+            Ok(v) => v,
+            Err(_) => return,
+        };
+        tokio::spawn(async move {
+            let mut buf = [0u8; 4096];
+            loop {
+                match stream.read(&mut buf).await {
+                    Ok(0) | Err(_) => return,
+                    Ok(read) => {
+                        if stream.write_all(&buf[..read]).await.is_err() {
+                            return;
+                        }
+                    }
+                }
+            }
+        });
+    }
+}
+
+// On f86f32b the client dials the local service *before* reading the request, gets a
+// connection refused, returns Err and simply drops the remote socket. The caller on
+// the other end sees an empty read instead of an error response.
+#[tokio::test(flavor = "multi_thread")]
+async fn local_unavailable_returns_502() {
+    let local_port = free_port();
+
+    let remote = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let remote_port = remote.local_addr().unwrap().port();
+    let (sockets_tx, mut sockets_rx) = mpsc::channel(16);
+    tokio::spawn(pooling_remote(remote, sockets_tx));
+
+    let api = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let api_port = api.local_addr().unwrap().port();
+    tokio::spawn(mock_api_server(api, Arc::new(AtomicU16::new(remote_port))));
+
+    let (shutdown_tx, _) = broadcast::channel(1);
+    let config = ClientConfig {
+        server: Some(format!("http://127.0.0.1:{api_port}")),
+        subdomain: Some("test".to_string()),
+        local_host: Some("127.0.0.1".to_string()),
+        local_port,
+        shutdown_signal: shutdown_tx.clone(),
+        max_conn: 1,
+        credential: None,
+        reregister_after: None,
+    };
+    open_tunnel(config).await.unwrap();
+
+    let mut socket = tokio::time::timeout(Duration::from_secs(5), sockets_rx.recv())
+        .await
+        .expect("client should offer a socket to the remote")
+        .expect("channel closed");
+
+    socket
+        .write_all(b"GET / HTTP/1.1\r\nHost: test\r\n\r\n")
+        .await
+        .unwrap();
+
+    let mut buf = vec![0u8; 1024];
+    let read = tokio::time::timeout(Duration::from_secs(5), socket.read(&mut buf))
+        .await
+        .expect("client must answer within 5s")
+        .expect("read failed");
+
+    assert!(
+        read > 0,
+        "client returned an empty read instead of an HTTP error response"
+    );
+    let response = String::from_utf8_lossy(&buf[..read]);
+    assert!(
+        response.starts_with("HTTP/1.1 502"),
+        "expected a 502 status line, got {response:?}"
+    );
+
+    let _ = shutdown_tx.send(());
+}
+
+// Non-regression baseline: this test must pass *both* before and after the fix. If it
+// goes green "too early", the test is not broken — that is its whole purpose.
+//
+// The idle period is 12 s, deliberately longer than HALF_CLOSE_GRACE (10 s). The grace
+// window must never apply here: it only starts counting once one direction has already
+// reached EOF, and in a live websocket-like connection neither direction ever does.
+//
+// The test is intentionally slow (~13 s) — that is the price of checking a grace window
+// on the real clock. `tokio::time::pause()` is incompatible with tests over real sockets.
+#[tokio::test(flavor = "multi_thread")]
+async fn live_bidirectional_connection_survives_idle_period() {
+    let local = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let local_port = local.local_addr().unwrap().port();
+    tokio::spawn(local_echo(local));
+
+    let remote = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let remote_port = remote.local_addr().unwrap().port();
+    let (sockets_tx, mut sockets_rx) = mpsc::channel(16);
+    tokio::spawn(pooling_remote(remote, sockets_tx));
+
+    let api = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let api_port = api.local_addr().unwrap().port();
+    tokio::spawn(mock_api_server(api, Arc::new(AtomicU16::new(remote_port))));
+
+    let (shutdown_tx, _) = broadcast::channel(1);
+    let config = ClientConfig {
+        server: Some(format!("http://127.0.0.1:{api_port}")),
+        subdomain: Some("test".to_string()),
+        local_host: Some("127.0.0.1".to_string()),
+        local_port,
+        shutdown_signal: shutdown_tx.clone(),
+        max_conn: 1,
+        credential: None,
+        reregister_after: None,
+    };
+    open_tunnel(config).await.unwrap();
+
+    let mut socket = tokio::time::timeout(Duration::from_secs(5), sockets_rx.recv())
+        .await
+        .expect("client should offer a socket to the remote")
+        .expect("channel closed");
+
+    socket.write_all(b"ping-1").await.unwrap();
+    let mut buf = [0u8; 6];
+    tokio::time::timeout(Duration::from_secs(5), socket.read_exact(&mut buf))
+        .await
+        .expect("first echo must come back within 5s")
+        .expect("read failed");
+    assert_eq!(&buf, b"ping-1", "the splice must be up in both directions");
+
+    sleep(Duration::from_secs(12)).await;
+
+    socket.write_all(b"ping-2").await.unwrap();
+    let mut buf = [0u8; 6];
+    tokio::time::timeout(Duration::from_secs(5), socket.read_exact(&mut buf))
+        .await
+        .expect("second echo must come back within 5s")
+        .expect("read failed");
+    assert_eq!(
+        &buf, b"ping-2",
+        "a connection with both halves alive must survive an idle period longer than the half-close grace"
+    );
+
+    let _ = shutdown_tx.send(());
+}

--- a/client/tests/proxy_half_close.rs
+++ b/client/tests/proxy_half_close.rs
@@ -103,6 +103,8 @@ async fn local_unavailable_returns_502() {
         max_conn: 1,
         credential: None,
         reregister_after: None,
+        reconnect_base_delay: None,
+        reconnect_max_delay: None,
     };
     open_tunnel(config).await.unwrap();
 
@@ -169,6 +171,8 @@ async fn live_bidirectional_connection_survives_idle_period() {
         max_conn: 1,
         credential: None,
         reregister_after: None,
+        reconnect_base_delay: None,
+        reconnect_max_delay: None,
     };
     open_tunnel(config).await.unwrap();
 

--- a/client/tests/reconnect_backoff.rs
+++ b/client/tests/reconnect_backoff.rs
@@ -1,0 +1,346 @@
+use std::collections::VecDeque;
+use std::sync::{
+    atomic::{AtomicU16, AtomicU32, Ordering},
+    Arc, Mutex,
+};
+use std::time::Instant;
+
+use localtunnel_client::{broadcast, open_tunnel, ClientConfig};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::task::JoinHandle;
+use tokio::time::{sleep, timeout, Duration};
+
+async fn mock_api_server(listener: TcpListener, endpoint_port: Arc<AtomicU16>) {
+    loop {
+        let (mut stream, _) = match listener.accept().await {
+            Ok(v) => v,
+            Err(_) => return,
+        };
+        let mut buf = [0u8; 4096];
+        let _ = stream.read(&mut buf).await;
+
+        let port = endpoint_port.load(Ordering::Relaxed);
+        let body = format!(
+            r#"{{"id":"test","port":{port},"max_conn_count":10,"url":"http://test.127.0.0.1:{port}"}}"#,
+        );
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+            body.len(),
+        );
+        let _ = stream.write_all(response.as_bytes()).await;
+    }
+}
+
+/// A remote endpoint that accepts every socket and drops it at once: the server is
+/// restarting, its pool is full, or it refuses the socket outright. Unlike a plain
+/// counter this records *when* each socket was offered — the phase is about the interval
+/// between reconnects growing, and a total says nothing about an interval.
+async fn accept_and_close(listener: TcpListener, log: Arc<Mutex<Vec<Instant>>>) {
+    loop {
+        match listener.accept().await {
+            Ok((stream, _)) => {
+                log.lock()
+                    .expect("accept log is not poisoned")
+                    .push(Instant::now());
+                drop(stream);
+            }
+            Err(_) => return,
+        }
+    }
+}
+
+/// A listener that holds every accepted socket open, standing in for a service that is
+/// up but silent. Used where the mock must not contribute failures of its own.
+async fn accept_hold(listener: TcpListener) {
+    let mut held = Vec::new();
+    loop {
+        match listener.accept().await {
+            Ok((stream, _)) => held.push(stream),
+            Err(_) => return,
+        }
+    }
+}
+
+/// Stands in for the tunnel server's socket pool: sockets the client offered and that are
+/// waiting for a request. `accepted` counts every socket ever offered.
+struct RemotePool {
+    sockets: tokio::sync::Mutex<VecDeque<TcpStream>>,
+    accepted: AtomicU32,
+}
+
+async fn pooled_remote(listener: TcpListener, pool: Arc<RemotePool>) {
+    loop {
+        match listener.accept().await {
+            Ok((stream, _)) => {
+                pool.accepted.fetch_add(1, Ordering::Relaxed);
+                pool.sockets.lock().await.push_back(stream);
+            }
+            Err(_) => return,
+        }
+    }
+}
+
+/// Take a socket the client is holding in the pool, send a minimal request and read the
+/// reply, exactly as the real server does when a browser hits the tunnel. Sockets the
+/// client has already closed are discarded on the way. Returns `None` if no live socket
+/// appeared within `wait` — that is precisely the "pool starved" condition.
+async fn request_through_pool(pool: &RemotePool, wait: Duration) -> Option<String> {
+    let deadline = Instant::now() + wait;
+    while Instant::now() < deadline {
+        let socket = pool.sockets.lock().await.pop_front();
+        let mut socket = match socket {
+            Some(socket) => socket,
+            None => {
+                sleep(Duration::from_millis(50)).await;
+                continue;
+            }
+        };
+        if socket
+            .write_all(b"GET / HTTP/1.1\r\nHost: test\r\nConnection: close\r\n\r\n")
+            .await
+            .is_err()
+        {
+            continue;
+        }
+        // Read until the reply has a body rather than until EOF: the local service behind
+        // the tunnel is a keep-alive server that answers and keeps the socket open, so
+        // waiting for EOF would time out and throw away a perfectly good `200 OK`. A
+        // `502 Bad Gateway` written by the client is a *live* socket too — the tunnel
+        // answered — and it satisfies the same condition. Only an empty read or an I/O
+        // error means the client had already dropped this socket.
+        let mut response = Vec::new();
+        let mut buf = [0u8; 4096];
+        let read_deadline = Instant::now() + Duration::from_secs(1);
+        loop {
+            let remaining = read_deadline.saturating_duration_since(Instant::now());
+            match timeout(remaining, socket.read(&mut buf)).await {
+                Ok(Ok(0)) | Ok(Err(_)) | Err(_) => break,
+                Ok(Ok(read)) => {
+                    response.extend_from_slice(&buf[..read]);
+                    let headers_done = response.windows(4).any(|window| window == b"\r\n\r\n");
+                    if headers_done && !response.ends_with(b"\r\n\r\n") {
+                        break;
+                    }
+                }
+            }
+        }
+        if response.is_empty() {
+            continue;
+        }
+        return Some(String::from_utf8_lossy(&response).to_string());
+    }
+    None
+}
+
+/// Minimal HTTP/1.1 server answering `200 OK` with `tag` as the body. The returned handle
+/// is what lets a test "kill" the service with `abort()`.
+async fn local_http(port: u16, tag: &'static str) -> JoinHandle<()> {
+    let listener = TcpListener::bind(("127.0.0.1", port))
+        .await
+        .expect("the local service should bind its port");
+    tokio::spawn(async move {
+        loop {
+            let (mut stream, _) = match listener.accept().await {
+                Ok(v) => v,
+                Err(_) => return,
+            };
+            tokio::spawn(async move {
+                let mut buf = [0u8; 4096];
+                loop {
+                    match stream.read(&mut buf).await {
+                        Ok(0) | Err(_) => return,
+                        Ok(_) => {
+                            let response = format!(
+                                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\n\r\n{tag}",
+                                tag.len(),
+                            );
+                            if stream.write_all(response.as_bytes()).await.is_err() {
+                                return;
+                            }
+                        }
+                    }
+                }
+            });
+        }
+    })
+}
+
+/// A port number nobody is listening on: needed when the port has to be known *before*
+/// the service that will own it is started.
+fn free_port() -> u16 {
+    std::net::TcpListener::bind("127.0.0.1:0")
+        .expect("binding an ephemeral port should succeed")
+        .local_addr()
+        .expect("a bound listener has a local address")
+        .port()
+}
+
+// A remote that keeps refusing sockets must get cheaper to retry, not just be retried
+// forever at a fixed rate. The test compares the density of reconnects in an early and a
+// late window of the same run: a flat delay makes the two windows look alike, growth
+// empties the late one. A total count cannot tell those apart, which is why this asserts
+// on the distribution in time instead.
+#[tokio::test(flavor = "multi_thread")]
+async fn reconnect_attempts_slow_down_while_the_remote_keeps_closing_sockets() {
+    let local = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("local mock should bind");
+    let local_port = local.local_addr().unwrap().port();
+    tokio::spawn(accept_hold(local));
+
+    let remote = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("remote mock should bind");
+    let remote_port = remote.local_addr().unwrap().port();
+    let remote_accepts = Arc::new(Mutex::new(Vec::new()));
+    tokio::spawn(accept_and_close(remote, remote_accepts.clone()));
+
+    let api = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("api mock should bind");
+    let api_port = api.local_addr().unwrap().port();
+    tokio::spawn(mock_api_server(api, Arc::new(AtomicU16::new(remote_port))));
+
+    // The re-registration window is deliberately far out of reach: this test measures how
+    // often a connection task reconnects, not whether the tunnel re-registers. The backoff
+    // bounds are given explicitly so the test never depends on the shipped defaults.
+    let (shutdown_tx, _) = broadcast::channel(1);
+    let config = ClientConfig {
+        server: Some(format!("http://127.0.0.1:{api_port}")),
+        subdomain: Some("test".to_string()),
+        local_host: Some("127.0.0.1".to_string()),
+        local_port,
+        shutdown_signal: shutdown_tx.clone(),
+        max_conn: 10,
+        credential: None,
+        reregister_after: Some(Duration::from_secs(60)),
+        reconnect_base_delay: Some(Duration::from_millis(500)),
+        reconnect_max_delay: Some(Duration::from_secs(30)),
+    };
+    open_tunnel(config).await.expect("tunnel should register");
+    let started = Instant::now();
+
+    sleep(Duration::from_secs(6)).await;
+    let _ = shutdown_tx.send(());
+
+    let stamps: Vec<Duration> = {
+        let log = remote_accepts.lock().expect("accept log is not poisoned");
+        log.iter()
+            .map(|at| at.saturating_duration_since(started))
+            .collect()
+    };
+    let early = stamps
+        .iter()
+        .filter(|elapsed| **elapsed < Duration::from_millis(1500))
+        .count();
+    let late = stamps
+        .iter()
+        .filter(|elapsed| {
+            **elapsed >= Duration::from_millis(4500) && **elapsed < Duration::from_millis(5500)
+        })
+        .count();
+
+    // A pool of ten tasks retries at the base delay while the failure is fresh: anything
+    // near ten means a task connected once and then sat on a multi-second fixed sleep.
+    assert!(
+        early >= 15,
+        "only {early} reconnects in the first 1.5 s (timeline: {stamps:?}) — \
+         the base reconnect delay is not being used"
+    );
+    // The point of the phase: the same failure repeated must get cheaper over time. With a
+    // flat delay this window looks exactly like the early one.
+    assert!(
+        late <= 3,
+        "{late} reconnects between 4.5 s and 5.5 s (early window had {early}) — \
+         the reconnect interval is not growing, the delay is still flat"
+    );
+    assert!(
+        stamps.len() <= 200,
+        "reconnects are spinning: {} attempts in six seconds",
+        stamps.len()
+    );
+}
+
+// A local service that is down says nothing about the remote endpoint, so the pool of
+// offered sockets must stay populated throughout the outage (the tunnel answers 502
+// instead of refusing the connection), and the moment the service is back the very next
+// request must be served — in well under the ten seconds this phase replaces.
+#[tokio::test(flavor = "multi_thread")]
+async fn local_outage_does_not_starve_the_pool_and_recovers_fast() {
+    let local_port = free_port();
+
+    let remote = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("remote mock should bind");
+    let remote_port = remote.local_addr().unwrap().port();
+    let pool = Arc::new(RemotePool {
+        sockets: tokio::sync::Mutex::new(VecDeque::new()),
+        accepted: AtomicU32::new(0),
+    });
+    tokio::spawn(pooled_remote(remote, pool.clone()));
+
+    let api = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("api mock should bind");
+    let api_port = api.local_addr().unwrap().port();
+    tokio::spawn(mock_api_server(api, Arc::new(AtomicU16::new(remote_port))));
+
+    // The ceiling is set explicitly and low: this test must never wait on the shipped
+    // 30 s default. That the sequence really climbs to 30 s is covered by the unit test
+    // `backoff_never_exceeds_the_cap`.
+    let (shutdown_tx, _) = broadcast::channel(1);
+    let config = ClientConfig {
+        server: Some(format!("http://127.0.0.1:{api_port}")),
+        subdomain: Some("test".to_string()),
+        local_host: Some("127.0.0.1".to_string()),
+        local_port,
+        shutdown_signal: shutdown_tx.clone(),
+        max_conn: 5,
+        credential: None,
+        reregister_after: Some(Duration::from_secs(60)),
+        reconnect_base_delay: None,
+        reconnect_max_delay: Some(Duration::from_secs(2)),
+    };
+    open_tunnel(config).await.expect("tunnel should register");
+
+    timeout(Duration::from_secs(5), async {
+        while pool.accepted.load(Ordering::Relaxed) < 5 {
+            sleep(Duration::from_millis(50)).await;
+        }
+    })
+    .await
+    .expect("the client should fill the remote pool");
+
+    let mut starved = 0;
+    for _ in 0..10 {
+        sleep(Duration::from_millis(500)).await;
+        if request_through_pool(&pool, Duration::from_secs(1))
+            .await
+            .is_none()
+        {
+            starved += 1;
+        }
+    }
+
+    let _local = local_http(local_port, "V2").await;
+    let restarted_at = Instant::now();
+    let mut recovered = None;
+    while restarted_at.elapsed() < Duration::from_millis(1500) {
+        if let Some(response) = request_through_pool(&pool, Duration::from_millis(300)).await {
+            if response.contains("200 OK") && response.contains("V2") {
+                recovered = Some(restarted_at.elapsed());
+                break;
+            }
+        }
+        sleep(Duration::from_millis(100)).await;
+    }
+    let recovered = recovered
+        .expect("the local service came back but the tunnel did not pick it up within 1.5 s");
+    assert_eq!(
+        starved, 0,
+        "the pool ran dry while only the local service was down (recovered after {recovered:?})"
+    );
+
+    let _ = shutdown_tx.send(());
+}

--- a/client/tests/remote_close_recovery.rs
+++ b/client/tests/remote_close_recovery.rs
@@ -116,6 +116,8 @@ async fn pool_recovers_after_remote_closes_every_socket() {
         max_conn: 10,
         credential: None,
         reregister_after: None,
+        reconnect_base_delay: None,
+        reconnect_max_delay: None,
     };
     open_tunnel(config).await.unwrap();
 
@@ -166,6 +168,8 @@ async fn no_local_connection_before_first_byte() {
         max_conn: 10,
         credential: None,
         reregister_after: None,
+        reconnect_base_delay: None,
+        reconnect_max_delay: None,
     };
     open_tunnel(config).await.unwrap();
 

--- a/client/tests/remote_close_recovery.rs
+++ b/client/tests/remote_close_recovery.rs
@@ -1,0 +1,191 @@
+use std::sync::{
+    atomic::{AtomicBool, AtomicU16, AtomicU32, Ordering},
+    Arc,
+};
+
+use localtunnel_client::{broadcast, open_tunnel, ClientConfig};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+use tokio::time::{sleep, Duration};
+
+async fn mock_api_server(listener: TcpListener, endpoint_port: Arc<AtomicU16>) {
+    loop {
+        let (mut stream, _) = match listener.accept().await {
+            Ok(v) => v,
+            Err(_) => return,
+        };
+        let mut buf = [0u8; 4096];
+        let _ = stream.read(&mut buf).await;
+
+        let port = endpoint_port.load(Ordering::Relaxed);
+        let body = format!(
+            r#"{{"id":"test","port":{port},"max_conn_count":10,"url":"http://test.127.0.0.1:{port}"}}"#,
+        );
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+            body.len(),
+        );
+        let _ = stream.write_all(response.as_bytes()).await;
+    }
+}
+
+// Accepts and then *holds* every connection open, never closing it. This models a
+// real HTTP server sitting on an idle keep-alive connection, and it is a necessary
+// condition for reproducing the stall: as long as the local side never sends EOF,
+// a bidirectional copy that waits for both directions can never return.
+async fn local_keepalive(listener: TcpListener, accepts: Arc<AtomicU32>) {
+    let mut held = Vec::new();
+    loop {
+        match listener.accept().await {
+            Ok((stream, _)) => {
+                accepts.fetch_add(1, Ordering::Relaxed);
+                held.push(stream);
+            }
+            Err(_) => return,
+        }
+    }
+}
+
+// While `closing` is true every accepted socket is dropped immediately (FIN), which
+// is exactly what the server does today on the `Reached sockets max` path in
+// `server/src/state.rs` and while it restarts. Once `closing` flips to false the
+// remote is healthy again: sockets are counted and pooled.
+async fn flaky_remote(listener: TcpListener, closing: Arc<AtomicBool>, pooled: Arc<AtomicU32>) {
+    let mut held = Vec::new();
+    loop {
+        let (stream, _) = match listener.accept().await {
+            Ok(v) => v,
+            Err(_) => return,
+        };
+        if closing.load(Ordering::Relaxed) {
+            drop(stream);
+        } else {
+            pooled.fetch_add(1, Ordering::Relaxed);
+            held.push(stream);
+        }
+    }
+}
+
+// Accepts, counts and holds sockets without ever writing anything into them. This is
+// the "socket parked in the server's pool, no request yet" state.
+async fn holding_remote(listener: TcpListener, pooled: Arc<AtomicU32>) {
+    let mut held = Vec::new();
+    loop {
+        match listener.accept().await {
+            Ok((stream, _)) => {
+                pooled.fetch_add(1, Ordering::Relaxed);
+                held.push(stream);
+            }
+            Err(_) => return,
+        }
+    }
+}
+
+// This is the issue #8 regression test and it fails on f86f32b. There, the remote
+// closing a pooled socket makes the remote -> local direction hit EOF, but the live
+// local keep-alive connection never produces the second EOF, so the bidirectional
+// copy future never completes. The connection task never returns, its semaphore
+// permit is never released, all max_conn permits leak and no new socket is ever
+// offered — `pooled` stays 0 forever, even after the remote is healthy again.
+#[tokio::test(flavor = "multi_thread")]
+async fn pool_recovers_after_remote_closes_every_socket() {
+    let local = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let local_port = local.local_addr().unwrap().port();
+    let local_accepts = Arc::new(AtomicU32::new(0));
+    tokio::spawn(local_keepalive(local, local_accepts));
+
+    let remote = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let remote_port = remote.local_addr().unwrap().port();
+    let closing = Arc::new(AtomicBool::new(true));
+    let pooled = Arc::new(AtomicU32::new(0));
+    tokio::spawn(flaky_remote(remote, closing.clone(), pooled.clone()));
+
+    let api = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let api_port = api.local_addr().unwrap().port();
+    tokio::spawn(mock_api_server(api, Arc::new(AtomicU16::new(remote_port))));
+
+    // `reregister_after: None` on purpose: recovery must be proven *without* the
+    // re-registration mechanism, otherwise this test measures the wrong thing.
+    let (shutdown_tx, _) = broadcast::channel(1);
+    let config = ClientConfig {
+        server: Some(format!("http://127.0.0.1:{api_port}")),
+        subdomain: Some("test".to_string()),
+        local_host: Some("127.0.0.1".to_string()),
+        local_port,
+        shutdown_signal: shutdown_tx.clone(),
+        max_conn: 10,
+        credential: None,
+        reregister_after: None,
+    };
+    open_tunnel(config).await.unwrap();
+
+    // Phase 1: the remote is down and closes every socket it accepts.
+    sleep(Duration::from_secs(3)).await;
+
+    // Phase 2: the remote is healthy again and pools sockets.
+    closing.store(false, Ordering::Relaxed);
+
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while pooled.load(Ordering::Relaxed) == 0 {
+            sleep(Duration::from_millis(50)).await;
+        }
+    })
+    .await
+    .expect("tunnel must offer sockets again within 5s after the remote recovered");
+
+    let _ = shutdown_tx.send(());
+}
+
+// A socket parked in the server's pool has no request on it yet, so there is nothing
+// for the local service to answer. Dialing the local service before the first byte
+// arrives burns a local connection (and a local server slot) per pooled socket. On
+// f86f32b the local connect happens eagerly, so this counts max_conn accepts.
+#[tokio::test(flavor = "multi_thread")]
+async fn no_local_connection_before_first_byte() {
+    let local = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let local_port = local.local_addr().unwrap().port();
+    let local_accepts = Arc::new(AtomicU32::new(0));
+    tokio::spawn(local_keepalive(local, local_accepts.clone()));
+
+    let remote = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let remote_port = remote.local_addr().unwrap().port();
+    let pooled = Arc::new(AtomicU32::new(0));
+    tokio::spawn(holding_remote(remote, pooled.clone()));
+
+    let api = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let api_port = api.local_addr().unwrap().port();
+    tokio::spawn(mock_api_server(api, Arc::new(AtomicU16::new(remote_port))));
+
+    let (shutdown_tx, _) = broadcast::channel(1);
+    let config = ClientConfig {
+        server: Some(format!("http://127.0.0.1:{api_port}")),
+        subdomain: Some("test".to_string()),
+        local_host: Some("127.0.0.1".to_string()),
+        local_port,
+        shutdown_signal: shutdown_tx.clone(),
+        max_conn: 10,
+        credential: None,
+        reregister_after: None,
+    };
+    open_tunnel(config).await.unwrap();
+
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while pooled.load(Ordering::Relaxed) == 0 {
+            sleep(Duration::from_millis(50)).await;
+        }
+    })
+    .await
+    .expect("client should offer sockets to the remote");
+
+    // Give an eager local connect more than enough time to show up.
+    sleep(Duration::from_secs(1)).await;
+
+    assert_eq!(
+        local_accepts.load(Ordering::Relaxed),
+        0,
+        "client must not dial the local service before the first request byte arrives, got {} accepts",
+        local_accepts.load(Ordering::Relaxed)
+    );
+
+    let _ = shutdown_tx.send(());
+}

--- a/client/tests/reregistration.rs
+++ b/client/tests/reregistration.rs
@@ -80,6 +80,8 @@ async fn reregistration_on_remote_failure() {
         max_conn: 10,
         credential: None,
         reregister_after: Some(Duration::ZERO),
+        reconnect_base_delay: None,
+        reconnect_max_delay: None,
     };
     open_tunnel(config).await.unwrap();
 


### PR DESCRIPTION
Fixes #8.

## The problem

The issue reports that restarting the tunneled service leaves the tunnel permanently broken, and that restarting the service again does not help. Retry throttling (issue point 1) was already addressed by the two `sleep(10s)` calls on `main`, and the simple restart case (point 2) already recovered. What did not recover is this:

`proxy_through` used `io::copy_bidirectional`, which only returns once **both** directions have reached EOF. When the server closes a pooled socket — a server restart, or the `Reached sockets max` path in `server/src/state.rs` that drops the socket — the remote side sends FIN, but the local HTTP server keeps its idle keep-alive connection open. `copy_bidirectional` then never returns, the `Semaphore` permit acquired in `start_tunnel_connections` is never released, and after `max_conn` such events every permit has leaked. No new sockets are offered to the server, and because `record_failure()` was only reached from the `TcpStream::connect` error arm, re-registration never fired either. The tunnel is dead until the client process is restarted.

Reproduced with a test that closes every pooled socket for 3 seconds and then serves normally again: on `main` the pool stays empty indefinitely.

## The fix

**Lazy local connect.** The client no longer dials the local service when a socket joins the pool. It waits for the first byte from the remote via `peek`, and only then connects locally. A pooled socket that gets closed while idle is now noticed immediately instead of through a stuck copy. As a side effect, restarting the local service no longer tears down the whole pool — pooled sockets do not hold local connections any more, and a request that arrives while the local service is down gets a real `502 Bad Gateway` instead of an empty reply.

**Bounded half-close.** `copy_bidirectional` is replaced by two `io::copy` halves under `tokio::select!`. When one direction finishes, the other side's write half is shut down and the opposite direction gets a bounded grace window (`HALF_CLOSE_GRACE`, 10s) to flush. WebSocket and HTTP-upgrade traffic is unaffected by construction: while both directions are live neither `io::copy` completes, so the `select!` never fires and no timeout is ever created. Covered by `live_bidirectional_connection_survives_idle_period`.

**Outcome-based failure accounting.** `proxy_through` returns a `ConnOutcome` (`Served`, `RemoteClosedIdle`, `LocalUnavailable`, `RemoteConnectFailed`) which `RoundHealth::record_outcome` maps to health and backoff. "Server accepted and closed immediately" now counts against the endpoint and can trigger re-registration; an idle close after `IDLE_CLOSE_MIN_LIFETIME` does not, since normal pool recycling should not force re-registration. A local service being down never counts against the remote endpoint.

**Exponential reconnect backoff.** Both hardcoded `sleep(10s)` calls are gone. Each connection task keeps two independent curves, remote and local: 500ms base, doubling, 30s cap, with deterministic jitter derived from the task index — no `rand` dependency is added. A local service that comes back is picked up in about half a second instead of up to ten; a remote endpoint that keeps failing is retried ever more slowly instead of once per second.

## Breaking change

`ClientConfig` gains `reconnect_base_delay` and `reconnect_max_delay`, both `Option<Duration>`. Setting them to `None` keeps the shipped defaults, so the only change needed in existing code is adding the two fields to the struct literal.

## Tests

`cargo test --workspace` — 26 passed. `cargo clippy --workspace --all-targets -- -D warnings` — clean. No new dependencies (`cargo tree -e normal | grep -c rand` is 0).

New coverage:

- `remote_close_recovery.rs` — the pool recovers within 5s after the remote closes every socket (fails on `main`); no local connection is opened before the first byte
- `proxy_half_close.rs` — `502` when the local service is unavailable; a live connection survives a 12s idle period
- `instant_close_reregistration.rs` — instant remote close triggers re-registration; a local outage does not
- `reconnect_backoff.rs` — retry intervals grow while the remote keeps closing sockets; a local outage neither starves the pool nor delays recovery
- `local_restart_e2e.rs` — end-to-end against a real `localtunnel-server`: restart the tunneled service, the public URL serves it again. Green on `f86f32b` as well; it exists so the rewritten connection path cannot regress the scenario the issue is actually about.

The e2e test needs `localtunnel-server` as a dev-dependency of the client. It is a path dependency in `[dev-dependencies]`, which `cargo publish` strips from the published manifest.

## Deliberately out of scope

- `server/src/api.rs` — `ClientManager::put()` overwrites the subdomain entry with a fresh `Client` without any ownership check. With `require_auth=false` that means anyone can take over another user's subdomain. Worth a separate issue.
- `client/src/lib.rs` host parsing via `split("//")` / `split_once('.')` is fragile for a bare IP with no subdomain.
